### PR TITLE
Add durable live chunk persistence for audio streams

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,8 +1,13 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+<uses-permission android:name="android.permission.RECORD_AUDIO" />
+<uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+<uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />
+
 <application>
     <service
       android:name=".ForegroundService"
+      android:exported="false"
       android:foregroundServiceType="microphone" />
 </application>
 </manifest>

--- a/android/src/main/java/com/xitronix/capacitorvoicerec/CustomMediaRecorder.java
+++ b/android/src/main/java/com/xitronix/capacitorvoicerec/CustomMediaRecorder.java
@@ -34,6 +34,7 @@ public class CustomMediaRecorder {
     // Interface for status change callbacks
     public interface OnStatusChangeListener {
         void onStatusChange(CurrentRecordingStatus status);
+        default void onRecordingError(String reason) {}
     }
 
     public CustomMediaRecorder(Context context) {
@@ -58,6 +59,22 @@ public class CustomMediaRecorder {
         cleanupRecorder(); // Clean up any previous instance first
 
         mediaRecorder = new MediaRecorder();
+        mediaRecorder.setOnErrorListener((mr, what, extra) -> {
+            Log.e(TAG, "MediaRecorder error what=" + what + " extra=" + extra);
+            if (listener != null) {
+                listener.onRecordingError(what == MediaRecorder.MEDIA_ERROR_SERVER_DIED
+                    ? "mediaServerDied"
+                    : "mediaRecorderError:" + what);
+            }
+            cleanupRecorder();
+            setStatus(CurrentRecordingStatus.NONE);
+        });
+        mediaRecorder.setOnInfoListener((mr, what, extra) -> {
+            Log.w(TAG, "MediaRecorder info what=" + what + " extra=" + extra);
+            if (listener != null) {
+                listener.onRecordingError("mediaRecorderInfo:" + what);
+            }
+        });
         mediaRecorder.setAudioSource(MediaRecorder.AudioSource.MIC);
         mediaRecorder.setOutputFormat(MediaRecorder.OutputFormat.AAC_ADTS);
         mediaRecorder.setAudioEncoder(MediaRecorder.AudioEncoder.AAC);

--- a/android/src/main/java/com/xitronix/capacitorvoicerec/ForegroundService.java
+++ b/android/src/main/java/com/xitronix/capacitorvoicerec/ForegroundService.java
@@ -12,6 +12,7 @@ import android.os.Build;
 import android.os.IBinder;
 import android.util.Log;
 import androidx.core.app.NotificationCompat;
+import androidx.core.app.ServiceCompat;
 
 public class ForegroundService extends Service {
 
@@ -61,7 +62,7 @@ public class ForegroundService extends Service {
         // Start as foreground service with notification
         if (intent != null) {
             String iconName = intent.getStringExtra(EXTRA_ICON_RES_NAME);
-            startForeground(NOTIFICATION_ID, buildNotification(iconName));
+            startAsMicrophoneForegroundService(buildNotification(iconName));
 
             String action = intent.getAction();
             if (action != null && action.equals(ACTION_STOP_FOREGROUND_SERVICE)) {
@@ -89,7 +90,7 @@ public class ForegroundService extends Service {
             }
         } else {
             // If intent is null, still start foreground with default notification
-            startForeground(NOTIFICATION_ID, buildNotification(null));
+            startAsMicrophoneForegroundService(buildNotification(null));
         }
         
         // Default handling for continuation
@@ -163,6 +164,19 @@ public class ForegroundService extends Service {
         builder.addAction(android.R.drawable.ic_media_pause, "Stop Recording", pendingStopIntent);
         
         return builder.build();
+    }
+
+    private void startAsMicrophoneForegroundService(Notification notification) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            ServiceCompat.startForeground(
+                this,
+                NOTIFICATION_ID,
+                notification,
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE
+            );
+        } else {
+            startForeground(NOTIFICATION_ID, notification);
+        }
     }
 
     private void createNotificationChannel() {

--- a/android/src/main/java/com/xitronix/capacitorvoicerec/ForegroundService.java
+++ b/android/src/main/java/com/xitronix/capacitorvoicerec/ForegroundService.java
@@ -62,19 +62,27 @@ public class ForegroundService extends Service {
         if (intent != null) {
             String iconName = intent.getStringExtra(EXTRA_ICON_RES_NAME);
             startForeground(NOTIFICATION_ID, buildNotification(iconName));
-            
+
             String action = intent.getAction();
             if (action != null && action.equals(ACTION_STOP_FOREGROUND_SERVICE)) {
-                // If we have an active recorder in the service, stop it
+                // Prefer file-recording stop; if no active recorder, try streaming stop.
+                boolean stopped = false;
                 if (VoiceRecorder.getActiveRecorder() != null) {
                     try {
                         VoiceRecorder.getActiveRecorder().stopRecording();
+                        stopped = true;
                     } catch (Exception e) {
                         Log.e(TAG, "Error stopping recording in foreground service", e);
                     }
                 }
-                
-                // Stop the service
+                if (!stopped) {
+                    try {
+                        VoiceRecorder.onForegroundServiceStopRequestedForStreaming();
+                    } catch (Exception e) {
+                        Log.e(TAG, "Error stopping streaming in foreground service", e);
+                    }
+                }
+
                 stopForeground(true);
                 stopSelf();
                 return START_NOT_STICKY;

--- a/android/src/main/java/com/xitronix/capacitorvoicerec/VoiceRecorder.java
+++ b/android/src/main/java/com/xitronix/capacitorvoicerec/VoiceRecorder.java
@@ -3,6 +3,9 @@ package com.xitronix.capacitorvoicerec;
 import android.Manifest;
 import android.content.Context;
 import android.content.Intent;
+import android.content.SharedPreferences;
+import android.media.AudioAttributes;
+import android.media.AudioFocusRequest;
 import android.media.AudioManager;
 import android.media.MediaMetadataRetriever;
 import android.media.MediaPlayer;
@@ -41,9 +44,18 @@ public class VoiceRecorder extends Plugin implements CustomMediaRecorder.OnStatu
     static final String RECORD_AUDIO_ALIAS = "voice recording";
     private static final String TAG = "VoiceRecorderPlugin";
     private static final String EVENT_STATE_CHANGE = "recordingStateChange";
+    private static final String PREFS_NAME = "VoiceRecorderPrefs";
+    private static final String ACTIVE_RECORDING_SESSION_KEY = "active_recording_session";
 
     private CustomMediaRecorder customMediaRecorder;
     private boolean useForegroundService = false;
+    private String activeSessionId;
+    private long activeSessionStartedAtMs = 0;
+    private String activeRecordingFilePath;
+    private String activeRecordingDirectory;
+    private AudioFocusRequest audioFocusRequest;
+    private boolean recorderPausedForFocusLoss = false;
+    private final AudioManager.OnAudioFocusChangeListener audioFocusChangeListener = this::handleAudioFocusChange;
     // Whether the currently running foreground service was started for the streaming
     // path (true) or the file-recording path (false). Governs the stop-action behavior.
     private boolean foregroundServiceForStreaming = false;
@@ -74,6 +86,22 @@ public class VoiceRecorder extends Plugin implements CustomMediaRecorder.OnStatu
 
     @Override
     protected void handleOnDestroy() {
+        if (isStreaming || audioRecord != null) {
+            stopStreamingInternal();
+        }
+        if (customMediaRecorder != null && customMediaRecorder.getCurrentStatus() != CurrentRecordingStatus.NONE) {
+            persistActiveRecordingSession("INTERRUPTED", "pluginDestroyed");
+            try {
+                customMediaRecorder.stopRecording();
+            } catch (Exception e) {
+                Log.e(TAG, "Failed to stop recorder during plugin destroy", e);
+            }
+        }
+        if (useForegroundService && Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            stopForegroundService();
+        }
+        customMediaRecorder = null;
+        activeRecorder = null;
         if (activePlugin == this) {
             activePlugin = null;
         }
@@ -93,7 +121,19 @@ public class VoiceRecorder extends Plugin implements CustomMediaRecorder.OnStatu
     // Callback from CustomMediaRecorder
     @Override
     public void onStatusChange(CurrentRecordingStatus status) {
+        if (status != CurrentRecordingStatus.NONE) {
+            persistActiveRecordingSession(status.name(), null);
+        }
         notifyListeners(EVENT_STATE_CHANGE, ResponseGenerator.statusResponse(status));
+    }
+
+    @Override
+    public void onRecordingError(String reason) {
+        persistActiveRecordingSession("INTERRUPTED", reason);
+        JSObject data = new JSObject();
+        data.put("status", "INTERRUPTED");
+        data.put("reason", reason);
+        notifyListeners(EVENT_STATE_CHANGE, data);
     }
 
 
@@ -143,6 +183,11 @@ public class VoiceRecorder extends Plugin implements CustomMediaRecorder.OnStatu
 
     @PluginMethod
     public void startRecording(PluginCall call) {
+        if (isStreaming) {
+            call.reject("Audio streaming is already active");
+            return;
+        }
+
         if (!doesUserGaveAudioRecordingPermission()) {
             call.reject(Messages.MISSING_PERMISSION, RECORD_AUDIO_ALIAS); // Indicate which permission is missing
             return;
@@ -163,9 +208,17 @@ public class VoiceRecorder extends Plugin implements CustomMediaRecorder.OnStatu
         // Get options
         String directory = call.getString("directory", "DOCUMENTS");
         useForegroundService = Boolean.TRUE.equals(call.getBoolean("useForegroundService", false));
+        activeSessionId = java.util.UUID.randomUUID().toString();
+        activeSessionStartedAtMs = nowMs();
+        activeRecordingDirectory = directory;
         // this.currentDirectory = directory; // Store if needed
 
         try {
+             if (!requestAudioFocusForRecording()) {
+                 call.reject(Messages.MICROPHONE_BEING_USED);
+                 return;
+             }
+
              // Start foreground service if requested
             if (useForegroundService && Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                  startForegroundService(call);
@@ -177,6 +230,8 @@ public class VoiceRecorder extends Plugin implements CustomMediaRecorder.OnStatu
             activeRecorder = customMediaRecorder; // Update static reference
 
             String filePathUri = customMediaRecorder.startRecording(directory);
+            activeRecordingFilePath = filePathUri;
+            persistActiveRecordingSession(CurrentRecordingStatus.RECORDING.name(), null);
 
              // Initial response - duration is unknown (-1)
             RecordData recordData = new RecordData(
@@ -193,6 +248,7 @@ public class VoiceRecorder extends Plugin implements CustomMediaRecorder.OnStatu
                  customMediaRecorder.deleteOutputFile(); // Delete potentially corrupted file
                  customMediaRecorder = null;
              }
+             abandonAudioFocus();
              if (useForegroundService && Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                   stopForegroundService();
              }
@@ -202,6 +258,11 @@ public class VoiceRecorder extends Plugin implements CustomMediaRecorder.OnStatu
 
      @PluginMethod
      public void continueRecording(PluginCall call) {
+         if (isStreaming) {
+             call.reject("Audio streaming is already active");
+             return;
+         }
+
          if (!doesUserGaveAudioRecordingPermission()) {
              call.reject(Messages.MISSING_PERMISSION);
              return;
@@ -231,6 +292,10 @@ public class VoiceRecorder extends Plugin implements CustomMediaRecorder.OnStatu
          // Get previous file path and directory
          String prevFilePathUri = call.getString("filePath");
          String directory = call.getString("directory", "DOCUMENTS"); // Directory for the *new* segment
+         useForegroundService = Boolean.TRUE.equals(call.getBoolean("useForegroundService", useForegroundService));
+         activeSessionId = java.util.UUID.randomUUID().toString();
+         activeSessionStartedAtMs = nowMs();
+         activeRecordingDirectory = directory;
           // this.currentDirectory = directory;
 
           if (prevFilePathUri == null || prevFilePathUri.isEmpty()) {
@@ -247,6 +312,11 @@ public class VoiceRecorder extends Plugin implements CustomMediaRecorder.OnStatu
 
 
          try {
+              if (!requestAudioFocusForRecording()) {
+                  call.reject(Messages.MICROPHONE_BEING_USED);
+                  return;
+              }
+
               // Start foreground service if requested (and not already running, though state check above should handle this)
               if (useForegroundService && Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                   startForegroundService(call);
@@ -257,6 +327,9 @@ public class VoiceRecorder extends Plugin implements CustomMediaRecorder.OnStatu
              customMediaRecorder.setListener(this);
 
              String newSegmentPathUri = customMediaRecorder.continueRecording(prevFilePathUri, directory);
+             activeRecordingFilePath = newSegmentPathUri;
+             activeRecorder = customMediaRecorder;
+             persistActiveRecordingSession(CurrentRecordingStatus.RECORDING.name(), null);
 
               // Return info about the *new* segment being recorded
              RecordData recordData = new RecordData(
@@ -272,6 +345,7 @@ public class VoiceRecorder extends Plugin implements CustomMediaRecorder.OnStatu
                  // Don't delete the *previous* file on continue failure, but clean up the new instance
                  customMediaRecorder = null;
              }
+             abandonAudioFocus();
               if (useForegroundService && Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                   stopForegroundService();
              }
@@ -281,6 +355,7 @@ public class VoiceRecorder extends Plugin implements CustomMediaRecorder.OnStatu
                if (customMediaRecorder != null) {
                   customMediaRecorder = null;
               }
+               abandonAudioFocus();
                if (useForegroundService && Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                    stopForegroundService();
                }
@@ -327,10 +402,12 @@ public class VoiceRecorder extends Plugin implements CustomMediaRecorder.OnStatu
             } else {
                 RecordData recordData = new RecordData(duration, "audio/aac", finalPath); // Use direct path instead of URI
                 call.resolve(ResponseGenerator.dataResponse(recordData.toJSObject()));
+                clearActiveRecordingSession();
             }
 
         } catch (Exception exp) {
              Log.e(TAG, "Stop Recording failed", exp);
+             persistActiveRecordingSession("INTERRUPTED", "stopFailed");
              // Attempt to stop foreground service even if stopRecorder failed
               if (useForegroundService && Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                   stopForegroundService();
@@ -340,6 +417,8 @@ public class VoiceRecorder extends Plugin implements CustomMediaRecorder.OnStatu
             // Clean up the recorder instance after stopping
             customMediaRecorder = null;
             activeRecorder = null; // Clear static reference
+            recorderPausedForFocusLoss = false;
+            abandonAudioFocus();
         }
     }
 
@@ -351,6 +430,9 @@ public class VoiceRecorder extends Plugin implements CustomMediaRecorder.OnStatu
         }
         try {
             boolean paused = customMediaRecorder.pauseRecording();
+            if (paused) {
+                persistActiveRecordingSession(CurrentRecordingStatus.PAUSED.name(), null);
+            }
             call.resolve(ResponseGenerator.fromBoolean(paused));
         } catch (NotSupportedOsVersion exception) {
             call.reject(Messages.NOT_SUPPORTED_OS_VERSION);
@@ -373,6 +455,9 @@ public class VoiceRecorder extends Plugin implements CustomMediaRecorder.OnStatu
                 return;
             }
             boolean resumed = customMediaRecorder.resumeRecording();
+            if (resumed) {
+                persistActiveRecordingSession(CurrentRecordingStatus.RECORDING.name(), null);
+            }
             call.resolve(ResponseGenerator.fromBoolean(resumed));
         } catch (NotSupportedOsVersion exception) {
             call.reject(Messages.NOT_SUPPORTED_OS_VERSION);
@@ -390,6 +475,29 @@ public class VoiceRecorder extends Plugin implements CustomMediaRecorder.OnStatu
         } else {
             call.resolve(ResponseGenerator.statusResponse(customMediaRecorder.getCurrentStatus()));
         }
+    }
+
+    @PluginMethod
+    public void getActiveRecordingSession(PluginCall call) {
+        JSObject session = buildActiveRecordingSession(null, null);
+        if (session == null) {
+            session = loadPersistedRecordingSession();
+        }
+        JSObject response = new JSObject();
+        response.put("value", session);
+        call.resolve(response);
+    }
+
+    @PluginMethod
+    public void listRecoverableRecordingSessions(PluginCall call) {
+        JSArray sessions = new JSArray();
+        JSObject session = loadPersistedRecordingSession();
+        if (session != null && recoverySessionHasAudio(session)) {
+            sessions.put(session);
+        }
+        JSObject response = new JSObject();
+        response.put("sessions", sessions);
+        call.resolve(response);
     }
 
     /**
@@ -455,6 +563,7 @@ public class VoiceRecorder extends Plugin implements CustomMediaRecorder.OnStatu
         );
         
         call.resolve(ResponseGenerator.dataResponse(recordData.toJSObject()));
+        clearActiveRecordingSession();
     }
 
     @PluginMethod
@@ -530,6 +639,178 @@ public class VoiceRecorder extends Plugin implements CustomMediaRecorder.OnStatu
 
     private boolean doesUserGaveAudioRecordingPermission() {
         return getPermissionState(RECORD_AUDIO_ALIAS) == PermissionState.GRANTED;
+    }
+
+    private long nowMs() {
+        return System.currentTimeMillis();
+    }
+
+    private JSObject buildActiveRecordingSession(String statusOverride, String interruptionReason) {
+        String filePath = activeRecordingFilePath;
+        if (filePath == null && customMediaRecorder != null) {
+            filePath = customMediaRecorder.getOutputFilePathUri();
+        }
+        if (filePath == null) return null;
+
+        String status = statusOverride;
+        if (status == null) {
+            status = customMediaRecorder != null ? customMediaRecorder.getCurrentStatus().name() : "INTERRUPTED";
+        }
+
+        JSObject data = new JSObject();
+        data.put("sessionId", activeSessionId != null ? activeSessionId : new File(filePath).getName());
+        data.put("filePath", filePath);
+        data.put("status", status);
+        data.put("startedAt", activeSessionStartedAtMs > 0 ? activeSessionStartedAtMs : nowMs());
+        data.put("updatedAt", nowMs());
+        data.put("platform", "android");
+        data.put("hasSegments", hasRecoverableSegments(filePath));
+        if (activeRecordingDirectory != null) {
+            data.put("directory", activeRecordingDirectory);
+        }
+        if (interruptionReason != null) {
+            data.put("interruptionReason", interruptionReason);
+        }
+        return data;
+    }
+
+    private void persistActiveRecordingSession(String statusOverride, String interruptionReason) {
+        JSObject data = buildActiveRecordingSession(statusOverride, interruptionReason);
+        if (data == null) return;
+        getContext().getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .edit()
+            .putString(ACTIVE_RECORDING_SESSION_KEY, data.toString())
+            .apply();
+    }
+
+    private void clearActiveRecordingSession() {
+        getContext().getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .edit()
+            .remove(ACTIVE_RECORDING_SESSION_KEY)
+            .apply();
+        activeSessionId = null;
+        activeSessionStartedAtMs = 0;
+        activeRecordingFilePath = null;
+        activeRecordingDirectory = null;
+    }
+
+    private JSObject loadPersistedRecordingSession() {
+        SharedPreferences prefs = getContext().getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+        String raw = prefs.getString(ACTIVE_RECORDING_SESSION_KEY, null);
+        if (raw == null) return null;
+        try {
+            org.json.JSONObject parsed = new org.json.JSONObject(raw);
+            JSObject data = new JSObject();
+            java.util.Iterator<String> keys = parsed.keys();
+            while (keys.hasNext()) {
+                String key = keys.next();
+                data.put(key, parsed.get(key));
+            }
+            return data;
+        } catch (Exception e) {
+            Log.w(TAG, "Failed to parse active recording session", e);
+            return null;
+        }
+    }
+
+    private boolean recoverySessionHasAudio(JSObject session) {
+        String filePath = session.getString("filePath");
+        if (filePath == null) return false;
+        File file = new File(filePath.startsWith("file://") ? Uri.parse(filePath).getPath() : filePath);
+        return file.exists() || session.optBoolean("hasSegments", false);
+    }
+
+    private boolean hasRecoverableSegments(String filePath) {
+        if (filePath == null) return false;
+        File file = new File(filePath.startsWith("file://") ? Uri.parse(filePath).getPath() : filePath);
+        String key = "voice_recorder_segments_" + file.getName();
+        java.util.Set<String> savedSegments = getContext()
+            .getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .getStringSet(key, null);
+        if (savedSegments == null) return false;
+        for (String segment : savedSegments) {
+            File segmentFile = new File(segment);
+            if (segmentFile.exists() && segmentFile.length() > 0) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean requestAudioFocusForRecording() {
+        AudioManager manager = (AudioManager) getContext().getSystemService(Context.AUDIO_SERVICE);
+        if (manager == null) return false;
+
+        int result;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            AudioAttributes attributes = new AudioAttributes.Builder()
+                .setUsage(AudioAttributes.USAGE_VOICE_COMMUNICATION)
+                .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
+                .build();
+            audioFocusRequest = new AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN_TRANSIENT)
+                .setAudioAttributes(attributes)
+                .setOnAudioFocusChangeListener(audioFocusChangeListener)
+                .build();
+            result = manager.requestAudioFocus(audioFocusRequest);
+        } else {
+            result = manager.requestAudioFocus(
+                audioFocusChangeListener,
+                AudioManager.STREAM_VOICE_CALL,
+                AudioManager.AUDIOFOCUS_GAIN_TRANSIENT
+            );
+        }
+        return result == AudioManager.AUDIOFOCUS_REQUEST_GRANTED;
+    }
+
+    private void abandonAudioFocus() {
+        AudioManager manager = (AudioManager) getContext().getSystemService(Context.AUDIO_SERVICE);
+        if (manager == null) return;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && audioFocusRequest != null) {
+            manager.abandonAudioFocusRequest(audioFocusRequest);
+            audioFocusRequest = null;
+        } else {
+            manager.abandonAudioFocus(audioFocusChangeListener);
+        }
+    }
+
+    private void handleAudioFocusChange(int focusChange) {
+        if (focusChange == AudioManager.AUDIOFOCUS_GAIN) {
+            if (recorderPausedForFocusLoss && customMediaRecorder != null) {
+                try {
+                    if (customMediaRecorder.resumeRecording()) {
+                        recorderPausedForFocusLoss = false;
+                        persistActiveRecordingSession(CurrentRecordingStatus.RECORDING.name(), null);
+                    }
+                } catch (Exception e) {
+                    Log.e(TAG, "Failed to resume after audio focus gain", e);
+                }
+            }
+            return;
+        }
+
+        if (focusChange == AudioManager.AUDIOFOCUS_LOSS ||
+            focusChange == AudioManager.AUDIOFOCUS_LOSS_TRANSIENT) {
+            if (customMediaRecorder != null &&
+                customMediaRecorder.getCurrentStatus() == CurrentRecordingStatus.RECORDING) {
+                try {
+                    if (customMediaRecorder.pauseRecording()) {
+                        recorderPausedForFocusLoss = true;
+                        persistActiveRecordingSession("INTERRUPTED", "audioFocusLoss");
+                    }
+                } catch (Exception e) {
+                    persistActiveRecordingSession("INTERRUPTED", "audioFocusLoss");
+                    Log.e(TAG, "Failed to pause after audio focus loss", e);
+                }
+            }
+
+            if (isStreaming) {
+                JSObject data = new JSObject();
+                data.put("status", "INTERRUPTED");
+                data.put("reason", "audioFocusLoss");
+                notifyListeners(EVENT_STATE_CHANGE, data);
+                stopStreamingInternal();
+            }
+        }
     }
 
      private long getMsDurationOfAudioFile(String filePath) {
@@ -636,6 +917,11 @@ public class VoiceRecorder extends Plugin implements CustomMediaRecorder.OnStatu
             return;
         }
 
+        if (customMediaRecorder != null && customMediaRecorder.getCurrentStatus() != CurrentRecordingStatus.NONE) {
+            call.resolve(ResponseGenerator.failResponse());
+            return;
+        }
+
         // Check permissions first
         if (getPermissionState(RECORD_AUDIO_ALIAS) != PermissionState.GRANTED) {
             call.resolve(ResponseGenerator.failResponse());
@@ -664,6 +950,11 @@ public class VoiceRecorder extends Plugin implements CustomMediaRecorder.OnStatu
         String sessionId = call.getString("persistSessionId");
 
         try {
+            if (!requestAudioFocusForRecording()) {
+                call.resolve(ResponseGenerator.failResponse());
+                return;
+            }
+
             if (sessionId != null && !sessionId.isEmpty()) {
                 if (!isValidSessionId(sessionId)) {
                     Log.e(TAG, "Invalid persistSessionId (unsafe characters)");
@@ -715,6 +1006,7 @@ public class VoiceRecorder extends Plugin implements CustomMediaRecorder.OnStatu
             call.resolve(ResponseGenerator.successResponse());
         } catch (Exception e) {
             Log.e(TAG, "Error starting audio stream", e);
+            abandonAudioFocus();
             if (foregroundServiceForStreaming && Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                 stopForegroundService();
                 foregroundServiceForStreaming = false;
@@ -736,6 +1028,19 @@ public class VoiceRecorder extends Plugin implements CustomMediaRecorder.OnStatu
                 samplesRead = audioRecord.read(audioBuffer, 0, audioBuffer.length);
             } catch (Exception e) {
                 Log.e(TAG, "audioRecord.read failed", e);
+                JSObject data = new JSObject();
+                data.put("status", "INTERRUPTED");
+                data.put("reason", "audioRecordReadException");
+                notifyListeners(EVENT_STATE_CHANGE, data);
+                break;
+            }
+
+            if (samplesRead < 0) {
+                Log.e(TAG, "AudioRecord.read returned error: " + samplesRead);
+                JSObject data = new JSObject();
+                data.put("status", "INTERRUPTED");
+                data.put("reason", "audioRecordReadError:" + samplesRead);
+                notifyListeners(EVENT_STATE_CHANGE, data);
                 break;
             }
 
@@ -814,6 +1119,8 @@ public class VoiceRecorder extends Plugin implements CustomMediaRecorder.OnStatu
                 }
             }
         }
+        isStreaming = false;
+        stopStreamingInternal();
     }
 
     // --- Chunk persistence helpers ---
@@ -948,6 +1255,8 @@ public class VoiceRecorder extends Plugin implements CustomMediaRecorder.OnStatu
             try { audioRecord.release(); } catch (Exception ignored) {}
             audioRecord = null;
         }
+
+        abandonAudioFocus();
 
         AudioManager audioManager = (AudioManager) getContext().getSystemService(Context.AUDIO_SERVICE);
         if (audioManager != null) {

--- a/android/src/main/java/com/xitronix/capacitorvoicerec/VoiceRecorder.java
+++ b/android/src/main/java/com/xitronix/capacitorvoicerec/VoiceRecorder.java
@@ -22,7 +22,15 @@ import com.getcapacitor.annotation.Permission;
 import com.getcapacitor.annotation.PermissionCallback;
 
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.concurrent.atomic.AtomicInteger;
 
 @CapacitorPlugin(
     name = "VoiceRecorder",
@@ -36,16 +44,50 @@ public class VoiceRecorder extends Plugin implements CustomMediaRecorder.OnStatu
 
     private CustomMediaRecorder customMediaRecorder;
     private boolean useForegroundService = false;
+    // Whether the currently running foreground service was started for the streaming
+    // path (true) or the file-recording path (false). Governs the stop-action behavior.
+    private boolean foregroundServiceForStreaming = false;
     // private String currentDirectory = "DOCUMENTS"; // Store directory if needed across calls
 
     // Static reference to the active recorder for the foreground service
     private static CustomMediaRecorder activeRecorder;
+    // Static reference to the active plugin instance so the foreground service can
+    // stop streaming when the user dismisses the notification.
+    private static VoiceRecorder activePlugin;
+
+    // --- Live-chunk persistence (native-owned storage) ---
+    // Target on-disk format for persisted chunks: 16-bit little-endian PCM at 16 kHz mono.
+    // Matches what the server expects over the WebSocket, so WAV assembly is a header prepend.
+    private static final int LIVE_CHUNK_SAMPLE_RATE = 16000;
+    private static final int LIVE_CHUNK_CHANNELS = 1;
+    private static final int LIVE_CHUNK_BYTES_PER_SAMPLE = 2;
+    private static final String LIVE_CHUNK_ROOT = "live-session-chunks";
+
+    private String persistSessionId;
+    private File persistSessionDir;
+    private AtomicInteger persistSeq = new AtomicInteger(0);
 
     @Override
     public void load() {
-        // Initialization if needed when the plugin loads
-         // customMediaRecorder = new CustomMediaRecorder(getContext()); // Instantiate here? Or per recording? Per recording seems better.
-         // customMediaRecorder.setListener(this); // Set listener if instance is kept
+        activePlugin = this;
+    }
+
+    @Override
+    protected void handleOnDestroy() {
+        if (activePlugin == this) {
+            activePlugin = null;
+        }
+        super.handleOnDestroy();
+    }
+
+    /**
+     * Called from {@link ForegroundService} when the user dismisses the notification
+     * while a streaming session is active. Stops capture and releases resources.
+     */
+    static void onForegroundServiceStopRequestedForStreaming() {
+        VoiceRecorder plugin = activePlugin;
+        if (plugin == null) return;
+        plugin.stopStreamingInternal();
     }
 
     // Callback from CustomMediaRecorder
@@ -605,26 +647,44 @@ public class VoiceRecorder extends Plugin implements CustomMediaRecorder.OnStatu
         int channels = call.getInt("channels", 1);
         int requestedBufferSize = call.getInt("bufferSize", 4096);
 
-        streamingChannelConfig = channels == 1 ? 
-            android.media.AudioFormat.CHANNEL_IN_MONO : 
+        streamingChannelConfig = channels == 1 ?
+            android.media.AudioFormat.CHANNEL_IN_MONO :
             android.media.AudioFormat.CHANNEL_IN_STEREO;
 
         streamingBufferSize = Math.max(
             requestedBufferSize * 2, // Convert to bytes (16-bit samples)
             android.media.AudioRecord.getMinBufferSize(
-                streamingSampleRate, 
-                streamingChannelConfig, 
+                streamingSampleRate,
+                streamingChannelConfig,
                 streamingAudioFormat
             )
         );
 
+        boolean requestFgs = Boolean.TRUE.equals(call.getBoolean("useForegroundService", false));
+        String sessionId = call.getString("persistSessionId");
+
         try {
+            if (sessionId != null && !sessionId.isEmpty()) {
+                if (!isValidSessionId(sessionId)) {
+                    Log.e(TAG, "Invalid persistSessionId (unsafe characters)");
+                    call.resolve(ResponseGenerator.failResponse());
+                    return;
+                }
+                persistSessionId = sessionId;
+                persistSessionDir = ensureSessionDir(sessionId);
+                persistSeq.set(nextSeqForDir(persistSessionDir));
+            } else {
+                persistSessionId = null;
+                persistSessionDir = null;
+                persistSeq.set(0);
+            }
+
             // Configure audio session for voice chat
             AudioManager audioManager = (AudioManager) getContext().getSystemService(Context.AUDIO_SERVICE);
             if (audioManager != null) {
                 audioManager.setMode(AudioManager.MODE_IN_COMMUNICATION);
             }
-            
+
             // Use VOICE_COMMUNICATION source for better voice chat quality
             audioRecord = new android.media.AudioRecord(
                 android.media.MediaRecorder.AudioSource.VOICE_COMMUNICATION,
@@ -639,6 +699,12 @@ public class VoiceRecorder extends Plugin implements CustomMediaRecorder.OnStatu
                 return;
             }
 
+            if (requestFgs && Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                useForegroundService = true;
+                foregroundServiceForStreaming = true;
+                startForegroundService(call);
+            }
+
             audioRecord.startRecording();
             isStreaming = true;
 
@@ -649,19 +715,30 @@ public class VoiceRecorder extends Plugin implements CustomMediaRecorder.OnStatu
             call.resolve(ResponseGenerator.successResponse());
         } catch (Exception e) {
             Log.e(TAG, "Error starting audio stream", e);
+            if (foregroundServiceForStreaming && Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                stopForegroundService();
+                foregroundServiceForStreaming = false;
+            }
             call.resolve(ResponseGenerator.failResponse());
         }
     }
 
     private int bufferCount = 0;
     private int silentBufferCount = 0;
-    
+
     private void streamAudioData() {
+        Process.setThreadPriority(Process.THREAD_PRIORITY_URGENT_AUDIO);
         short[] audioBuffer = new short[streamingBufferSize / 2]; // 16-bit samples
-        
+
         while (isStreaming && audioRecord != null) {
-            int samplesRead = audioRecord.read(audioBuffer, 0, audioBuffer.length);
-            
+            int samplesRead;
+            try {
+                samplesRead = audioRecord.read(audioBuffer, 0, audioBuffer.length);
+            } catch (Exception e) {
+                Log.e(TAG, "audioRecord.read failed", e);
+                break;
+            }
+
             if (samplesRead > 0) {
                 // Convert to float array for consistency with web
                 float[] floatBuffer = new float[samplesRead];
@@ -670,12 +747,10 @@ public class VoiceRecorder extends Plugin implements CustomMediaRecorder.OnStatu
                     floatBuffer[i] = audioBuffer[i] / 32768.0f; // Normalize to [-1, 1]
                     sum += Math.abs(floatBuffer[i]);
                 }
-                
-                // Calculate audio level for monitoring (similar to iOS)
+
                 float avgLevel = sum / samplesRead;
                 bufferCount++;
-                
-                // Monitor audio levels periodically
+
                 if (bufferCount % 100 == 0) {
                     if (avgLevel < 0.001f) {
                         silentBufferCount++;
@@ -687,56 +762,170 @@ public class VoiceRecorder extends Plugin implements CustomMediaRecorder.OnStatu
                     }
                 }
 
-                // Send data to JavaScript - Convert float array to JSArray for proper JS compatibility
-                JSObject data = new JSObject();
-                
-                try {
-                    // Convert float[] to JSArray to ensure it's a proper JavaScript array
-                    com.getcapacitor.JSArray jsAudioData = new com.getcapacitor.JSArray();
-                    for (float sample : floatBuffer) {
-                        jsAudioData.put(sample);
+                // If persistence is enabled, downsample to 16 kHz mono and write to disk
+                // BEFORE emitting the JS event. This guarantees the chunk is durable
+                // even if the JS bridge is unhealthy.
+                Integer persistedSeq = null;
+                String persistedPath = null;
+                short[] pcm16kMono = null;
+                if (persistSessionId != null && persistSessionDir != null) {
+                    pcm16kMono = downsampleToMono16k(audioBuffer, samplesRead, streamingSampleRate);
+                    try {
+                        int seq = persistSeq.getAndIncrement();
+                        File chunkFile = writeChunkAtomic(persistSessionDir, seq, pcm16kMono);
+                        persistedSeq = seq;
+                        persistedPath = chunkFile.getAbsolutePath();
+                    } catch (IOException e) {
+                        Log.e(TAG, "Failed to persist chunk", e);
                     }
-                    
+                }
+
+                // Emit to JS
+                JSObject data = new JSObject();
+                try {
+                    com.getcapacitor.JSArray jsAudioData = new com.getcapacitor.JSArray();
+                    if (pcm16kMono != null) {
+                        // Emit the already-downsampled (normalized) samples so JS doesn't re-do work
+                        for (short s : pcm16kMono) {
+                            jsAudioData.put(s / 32768.0f);
+                        }
+                        data.put("sampleRate", LIVE_CHUNK_SAMPLE_RATE);
+                        data.put("channels", LIVE_CHUNK_CHANNELS);
+                        data.put("downsampled16kMono", true);
+                    } else {
+                        for (float sample : floatBuffer) {
+                            jsAudioData.put(sample);
+                        }
+                        data.put("sampleRate", streamingSampleRate);
+                        data.put("channels", streamingChannelConfig == android.media.AudioFormat.CHANNEL_IN_MONO ? 1 : 2);
+                        data.put("downsampled16kMono", false);
+                    }
+
                     data.put("audioData", jsAudioData);
-                    data.put("sampleRate", streamingSampleRate);
                     data.put("timestamp", System.currentTimeMillis());
-                    data.put("channels", streamingChannelConfig == android.media.AudioFormat.CHANNEL_IN_MONO ? 1 : 2);
+                    if (persistedSeq != null) {
+                        data.put("seq", persistedSeq.intValue());
+                        data.put("path", persistedPath);
+                    }
 
                     notifyListeners("audioData", data);
                 } catch (org.json.JSONException e) {
                     Log.e(TAG, "Error creating audio data JSON", e);
-                    // Continue streaming even if one buffer fails
                 }
             }
         }
     }
 
+    // --- Chunk persistence helpers ---
+
+    private static boolean isValidSessionId(String id) {
+        if (id == null || id.isEmpty() || id.length() > 128) return false;
+        for (int i = 0; i < id.length(); i++) {
+            char c = id.charAt(i);
+            boolean ok = (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+                         (c >= '0' && c <= '9') || c == '-' || c == '_';
+            if (!ok) return false;
+        }
+        return true;
+    }
+
+    private File liveChunkRootDir() {
+        File root = new File(getContext().getFilesDir(), LIVE_CHUNK_ROOT);
+        if (!root.exists()) root.mkdirs();
+        return root;
+    }
+
+    private File ensureSessionDir(String sessionId) {
+        File dir = new File(liveChunkRootDir(), sessionId);
+        if (!dir.exists()) dir.mkdirs();
+        return dir;
+    }
+
+    /** Scan existing chunk files in dir and return max(seq) + 1 so a restarted stream resumes cleanly. */
+    private static int nextSeqForDir(File dir) {
+        if (dir == null || !dir.exists()) return 0;
+        File[] files = dir.listFiles();
+        if (files == null) return 0;
+        int maxSeq = -1;
+        for (File f : files) {
+            String name = f.getName();
+            if (!name.endsWith(".pcm")) continue;
+            try {
+                int seq = Integer.parseInt(name.substring(0, name.length() - 4));
+                if (seq > maxSeq) maxSeq = seq;
+            } catch (NumberFormatException ignored) {
+            }
+        }
+        return maxSeq + 1;
+    }
+
+    private static String chunkFileName(int seq) {
+        return String.format(Locale.US, "%06d.pcm", seq);
+    }
+
+    private static File writeChunkAtomic(File dir, int seq, short[] samples) throws IOException {
+        File tmp = new File(dir, chunkFileName(seq) + ".tmp");
+        File fin = new File(dir, chunkFileName(seq));
+        ByteBuffer buf = ByteBuffer.allocate(samples.length * 2).order(ByteOrder.LITTLE_ENDIAN);
+        for (short s : samples) buf.putShort(s);
+        FileOutputStream fos = new FileOutputStream(tmp);
+        try {
+            fos.write(buf.array());
+            fos.getFD().sync();
+        } finally {
+            try { fos.close(); } catch (IOException ignored) {}
+        }
+        if (!tmp.renameTo(fin)) {
+            tmp.delete();
+            throw new IOException("Failed to rename chunk tmp -> final");
+        }
+        return fin;
+    }
+
+    /**
+     * Downsample 16-bit PCM mono at {@code inRate} to 16 kHz mono using simple integer-step
+     * decimation/interpolation. Good enough for voice; we are not doing phase-accurate resampling.
+     * For 48 kHz -> 16 kHz this is an exact 3:1 decimation with a 3-tap box filter.
+     */
+    private static short[] downsampleToMono16k(short[] samples, int length, int inRate) {
+        if (inRate == LIVE_CHUNK_SAMPLE_RATE) {
+            if (length == samples.length) return samples;
+            return Arrays.copyOf(samples, length);
+        }
+        // Integer step (3:1, 2:1, etc.) when inRate is a clean multiple
+        if (inRate % LIVE_CHUNK_SAMPLE_RATE == 0) {
+            int step = inRate / LIVE_CHUNK_SAMPLE_RATE;
+            int outLen = length / step;
+            short[] out = new short[outLen];
+            for (int i = 0; i < outLen; i++) {
+                int acc = 0;
+                int base = i * step;
+                for (int k = 0; k < step && base + k < length; k++) {
+                    acc += samples[base + k];
+                }
+                out[i] = (short) Math.max(-32768, Math.min(32767, acc / step));
+            }
+            return out;
+        }
+        // Fallback linear resampling
+        double ratio = (double) inRate / LIVE_CHUNK_SAMPLE_RATE;
+        int outLen = (int) Math.floor(length / ratio);
+        short[] out = new short[outLen];
+        for (int i = 0; i < outLen; i++) {
+            double srcPos = i * ratio;
+            int srcIdx = (int) srcPos;
+            double frac = srcPos - srcIdx;
+            short a = samples[srcIdx];
+            short b = srcIdx + 1 < length ? samples[srcIdx + 1] : a;
+            out[i] = (short) (a + (b - a) * frac);
+        }
+        return out;
+    }
+
     @PluginMethod
     public void stopAudioStream(PluginCall call) {
         try {
-            isStreaming = false;
-            
-            // Reset counters
-            bufferCount = 0;
-            silentBufferCount = 0;
-            
-            if (streamingThread != null) {
-                streamingThread.interrupt();
-                streamingThread = null;
-            }
-            
-            if (audioRecord != null) {
-                audioRecord.stop();
-                audioRecord.release();
-                audioRecord = null;
-            }
-            
-            // Reset audio mode to normal
-            AudioManager audioManager = (AudioManager) getContext().getSystemService(Context.AUDIO_SERVICE);
-            if (audioManager != null) {
-                audioManager.setMode(AudioManager.MODE_NORMAL);
-            }
-
+            stopStreamingInternal();
             call.resolve(ResponseGenerator.successResponse());
         } catch (Exception e) {
             Log.e(TAG, "Error stopping audio stream", e);
@@ -744,10 +933,287 @@ public class VoiceRecorder extends Plugin implements CustomMediaRecorder.OnStatu
         }
     }
 
+    private synchronized void stopStreamingInternal() {
+        isStreaming = false;
+        bufferCount = 0;
+        silentBufferCount = 0;
+
+        if (streamingThread != null) {
+            streamingThread.interrupt();
+            streamingThread = null;
+        }
+
+        if (audioRecord != null) {
+            try { audioRecord.stop(); } catch (Exception ignored) {}
+            try { audioRecord.release(); } catch (Exception ignored) {}
+            audioRecord = null;
+        }
+
+        AudioManager audioManager = (AudioManager) getContext().getSystemService(Context.AUDIO_SERVICE);
+        if (audioManager != null) {
+            audioManager.setMode(AudioManager.MODE_NORMAL);
+        }
+
+        if (foregroundServiceForStreaming && Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            stopForegroundService();
+            foregroundServiceForStreaming = false;
+        }
+
+        persistSessionId = null;
+        persistSessionDir = null;
+        persistSeq.set(0);
+    }
+
     @PluginMethod
     public void getStreamingStatus(PluginCall call) {
         JSObject result = new JSObject();
         result.put("status", isStreaming ? "STREAMING" : "STOPPED");
         call.resolve(result);
+    }
+
+    // --- Live-chunk plugin methods ---
+
+    @PluginMethod
+    public void listLiveChunkSessions(PluginCall call) {
+        JSArray arr = new JSArray();
+        File root = liveChunkRootDir();
+        File[] dirs = root.listFiles();
+        if (dirs != null) {
+            for (File d : dirs) {
+                if (d.isDirectory()) arr.put(d.getName());
+            }
+        }
+        JSObject res = new JSObject();
+        res.put("sessions", arr);
+        call.resolve(res);
+    }
+
+    @PluginMethod
+    public void listLiveChunks(PluginCall call) {
+        String sessionId = call.getString("sessionId");
+        if (!isValidSessionId(sessionId)) {
+            call.reject("Invalid sessionId");
+            return;
+        }
+        File dir = new File(liveChunkRootDir(), sessionId);
+        JSArray arr = new JSArray();
+        if (dir.exists()) {
+            File[] files = dir.listFiles();
+            if (files != null) {
+                Arrays.sort(files, (a, b) -> a.getName().compareTo(b.getName()));
+                for (File f : files) {
+                    String name = f.getName();
+                    if (!name.endsWith(".pcm")) continue;
+                    try {
+                        int seq = Integer.parseInt(name.substring(0, name.length() - 4));
+                        JSObject info = new JSObject();
+                        info.put("seq", seq);
+                        info.put("path", f.getAbsolutePath());
+                        info.put("size", f.length());
+                        arr.put(info);
+                    } catch (NumberFormatException ignored) {
+                    }
+                }
+            }
+        }
+        JSObject res = new JSObject();
+        res.put("chunks", arr);
+        call.resolve(res);
+    }
+
+    @PluginMethod
+    public void readLiveChunk(PluginCall call) {
+        String sessionId = call.getString("sessionId");
+        Integer seq = call.getInt("seq");
+        if (!isValidSessionId(sessionId) || seq == null) {
+            call.reject("Invalid sessionId or seq");
+            return;
+        }
+        File f = new File(new File(liveChunkRootDir(), sessionId), chunkFileName(seq));
+        if (!f.exists()) {
+            call.reject("Chunk not found");
+            return;
+        }
+        try {
+            byte[] bytes = new byte[(int) f.length()];
+            FileInputStream fis = new FileInputStream(f);
+            try {
+                int offset = 0;
+                while (offset < bytes.length) {
+                    int read = fis.read(bytes, offset, bytes.length - offset);
+                    if (read < 0) break;
+                    offset += read;
+                }
+            } finally {
+                try { fis.close(); } catch (IOException ignored) {}
+            }
+            String b64 = android.util.Base64.encodeToString(bytes, android.util.Base64.NO_WRAP);
+            JSObject res = new JSObject();
+            res.put("data", b64);
+            res.put("size", bytes.length);
+            call.resolve(res);
+        } catch (IOException e) {
+            call.reject("Failed to read chunk: " + e.getMessage());
+        }
+    }
+
+    @PluginMethod
+    public void deleteLiveChunk(PluginCall call) {
+        String sessionId = call.getString("sessionId");
+        Integer seq = call.getInt("seq");
+        if (!isValidSessionId(sessionId) || seq == null) {
+            call.reject("Invalid sessionId or seq");
+            return;
+        }
+        File f = new File(new File(liveChunkRootDir(), sessionId), chunkFileName(seq));
+        boolean ok = !f.exists() || f.delete();
+        call.resolve(ResponseGenerator.fromBoolean(ok));
+    }
+
+    @PluginMethod
+    public void deleteLiveChunkSession(PluginCall call) {
+        String sessionId = call.getString("sessionId");
+        if (!isValidSessionId(sessionId)) {
+            call.reject("Invalid sessionId");
+            return;
+        }
+        File dir = new File(liveChunkRootDir(), sessionId);
+        boolean ok = deleteRecursively(dir);
+        call.resolve(ResponseGenerator.fromBoolean(ok));
+    }
+
+    @PluginMethod
+    public void getLiveChunkSessionInfo(PluginCall call) {
+        String sessionId = call.getString("sessionId");
+        if (!isValidSessionId(sessionId)) {
+            call.reject("Invalid sessionId");
+            return;
+        }
+        File dir = new File(liveChunkRootDir(), sessionId);
+        long totalBytes = 0;
+        int count = 0;
+        int firstSeq = -1;
+        int lastSeq = -1;
+        if (dir.exists()) {
+            File[] files = dir.listFiles();
+            if (files != null) {
+                for (File f : files) {
+                    String name = f.getName();
+                    if (!name.endsWith(".pcm")) continue;
+                    try {
+                        int seq = Integer.parseInt(name.substring(0, name.length() - 4));
+                        totalBytes += f.length();
+                        count++;
+                        if (firstSeq == -1 || seq < firstSeq) firstSeq = seq;
+                        if (seq > lastSeq) lastSeq = seq;
+                    } catch (NumberFormatException ignored) {
+                    }
+                }
+            }
+        }
+        JSObject res = new JSObject();
+        res.put("totalBytes", totalBytes);
+        res.put("count", count);
+        res.put("firstSeq", firstSeq);
+        res.put("lastSeq", lastSeq);
+        res.put("dir", dir.getAbsolutePath());
+        call.resolve(res);
+    }
+
+    @PluginMethod
+    public void assembleLiveChunksToWav(PluginCall call) {
+        String sessionId = call.getString("sessionId");
+        String outputPath = call.getString("outputPath");
+        int sampleRate = call.getInt("sampleRate", LIVE_CHUNK_SAMPLE_RATE);
+        int channels = call.getInt("channels", LIVE_CHUNK_CHANNELS);
+        if (!isValidSessionId(sessionId) || outputPath == null || outputPath.isEmpty()) {
+            call.reject("Invalid sessionId or outputPath");
+            return;
+        }
+        File dir = new File(liveChunkRootDir(), sessionId);
+        if (!dir.exists()) {
+            call.reject("Session directory not found");
+            return;
+        }
+        File[] files = dir.listFiles();
+        if (files == null) files = new File[0];
+        Arrays.sort(files, (a, b) -> a.getName().compareTo(b.getName()));
+
+        long dataBytes = 0;
+        for (File f : files) {
+            if (f.getName().endsWith(".pcm")) dataBytes += f.length();
+        }
+        if (dataBytes == 0) {
+            call.reject("No chunks to assemble");
+            return;
+        }
+
+        File outFile = new File(outputPath);
+        File parent = outFile.getParentFile();
+        if (parent != null && !parent.exists()) parent.mkdirs();
+
+        try {
+            RandomAccessFile raf = new RandomAccessFile(outFile, "rw");
+            try {
+                // 44-byte WAV header
+                byte[] header = buildWavHeader(sampleRate, channels, dataBytes);
+                raf.write(header);
+                byte[] buffer = new byte[64 * 1024];
+                for (File f : files) {
+                    if (!f.getName().endsWith(".pcm")) continue;
+                    FileInputStream fis = new FileInputStream(f);
+                    try {
+                        int n;
+                        while ((n = fis.read(buffer)) > 0) {
+                            raf.write(buffer, 0, n);
+                        }
+                    } finally {
+                        try { fis.close(); } catch (IOException ignored) {}
+                    }
+                }
+                raf.getFD().sync();
+            } finally {
+                try { raf.close(); } catch (IOException ignored) {}
+            }
+        } catch (IOException e) {
+            call.reject("Failed to assemble WAV: " + e.getMessage());
+            return;
+        }
+
+        long msDuration = (dataBytes * 1000L) / ((long) sampleRate * channels * LIVE_CHUNK_BYTES_PER_SAMPLE);
+        JSObject res = new JSObject();
+        res.put("filePath", outFile.getAbsolutePath());
+        res.put("msDuration", msDuration);
+        res.put("size", outFile.length());
+        call.resolve(res);
+    }
+
+    private static byte[] buildWavHeader(int sampleRate, int channels, long dataBytes) {
+        ByteBuffer h = ByteBuffer.allocate(44).order(ByteOrder.LITTLE_ENDIAN);
+        h.put((byte) 'R').put((byte) 'I').put((byte) 'F').put((byte) 'F');
+        h.putInt((int) (36 + dataBytes));
+        h.put((byte) 'W').put((byte) 'A').put((byte) 'V').put((byte) 'E');
+        h.put((byte) 'f').put((byte) 'm').put((byte) 't').put((byte) ' ');
+        h.putInt(16); // fmt chunk size
+        h.putShort((short) 1); // PCM format
+        h.putShort((short) channels);
+        h.putInt(sampleRate);
+        h.putInt(sampleRate * channels * LIVE_CHUNK_BYTES_PER_SAMPLE);
+        h.putShort((short) (channels * LIVE_CHUNK_BYTES_PER_SAMPLE));
+        h.putShort((short) 16);
+        h.put((byte) 'd').put((byte) 'a').put((byte) 't').put((byte) 'a');
+        h.putInt((int) dataBytes);
+        return h.array();
+    }
+
+    private static boolean deleteRecursively(File f) {
+        if (f == null || !f.exists()) return true;
+        if (f.isDirectory()) {
+            File[] kids = f.listFiles();
+            if (kids != null) {
+                for (File k : kids) deleteRecursively(k);
+            }
+        }
+        return f.delete();
     }
 }

--- a/android/src/main/java/com/xitronix/capacitorvoicerec/VoiceRecorder.java
+++ b/android/src/main/java/com/xitronix/capacitorvoicerec/VoiceRecorder.java
@@ -804,11 +804,7 @@ public class VoiceRecorder extends Plugin implements CustomMediaRecorder.OnStatu
             }
 
             if (isStreaming) {
-                JSObject data = new JSObject();
-                data.put("status", "INTERRUPTED");
-                data.put("reason", "audioFocusLoss");
-                notifyListeners(EVENT_STATE_CHANGE, data);
-                stopStreamingInternal();
+                Log.i(TAG, "Ignoring audio focus loss during live streaming; AudioRecord remains authoritative");
             }
         }
     }
@@ -912,8 +908,13 @@ public class VoiceRecorder extends Plugin implements CustomMediaRecorder.OnStatu
 
     @PluginMethod
     public void startAudioStream(PluginCall call) {
+        String sessionId = call.getString("persistSessionId");
         if (isStreaming) {
-            call.resolve(ResponseGenerator.failResponse());
+            if (persistSessionId != null && persistSessionId.equals(sessionId)) {
+                call.resolve(ResponseGenerator.successResponse());
+            } else {
+                call.resolve(ResponseGenerator.failResponse());
+            }
             return;
         }
 
@@ -947,14 +948,7 @@ public class VoiceRecorder extends Plugin implements CustomMediaRecorder.OnStatu
         );
 
         boolean requestFgs = Boolean.TRUE.equals(call.getBoolean("useForegroundService", false));
-        String sessionId = call.getString("persistSessionId");
-
         try {
-            if (!requestAudioFocusForRecording()) {
-                call.resolve(ResponseGenerator.failResponse());
-                return;
-            }
-
             if (sessionId != null && !sessionId.isEmpty()) {
                 if (!isValidSessionId(sessionId)) {
                     Log.e(TAG, "Invalid persistSessionId (unsafe characters)");

--- a/ios/Plugin/CustomMediaRecorder.swift
+++ b/ios/Plugin/CustomMediaRecorder.swift
@@ -2,11 +2,17 @@ import Foundation
 import AVFoundation
 
 class CustomMediaRecorder:NSObject {
+    private static let recoverySessionKey = "capacitor_voice_rec_active_session"
+
     private var recordingSession: AVAudioSession!
     private var audioRecorder: AVAudioRecorder!
     private var audioFilePath: URL!
     private var originalRecordingSessionCategory: AVAudioSession.Category!
     private var currentTempRecordingPath: URL?
+    private var notificationObserversInstalled = false
+    private var sessionId: String?
+    private var sessionStartedAtMs: Int?
+    private var currentDirectory: String?
 
     private var _status = CurrentRecordingStatus.NONE
     var onStatusChange: ((CurrentRecordingStatus) -> Void)?
@@ -59,6 +65,9 @@ class CustomMediaRecorder:NSObject {
      * Set up notification observers for audio session events
      */
     private func setupNotificationObservers() {
+        guard !notificationObserversInstalled else { return }
+        notificationObserversInstalled = true
+
         NotificationCenter.default.addObserver(self,
                                              selector: #selector(handleInterruption),
                                              name: AVAudioSession.interruptionNotification,
@@ -70,6 +79,10 @@ class CustomMediaRecorder:NSObject {
         NotificationCenter.default.addObserver(self,
                                              selector: #selector(handleMediaServicesReset),
                                              name: AVAudioSession.mediaServicesWereResetNotification,
+                                             object: AVAudioSession.sharedInstance())
+        NotificationCenter.default.addObserver(self,
+                                             selector: #selector(handleRouteChange),
+                                             name: AVAudioSession.routeChangeNotification,
                                              object: AVAudioSession.sharedInstance())
     }
     
@@ -104,6 +117,9 @@ class CustomMediaRecorder:NSObject {
     public func startRecording(directory: String?) -> Bool {
         // Set up notification observers
         setupNotificationObservers()
+        currentDirectory = directory
+        sessionId = UUID().uuidString
+        sessionStartedAtMs = Self.nowMs()
         
         // Configure audio session
         if !setupAudioSession() {
@@ -132,6 +148,7 @@ class CustomMediaRecorder:NSObject {
             }
             
             status = CurrentRecordingStatus.RECORDING
+            persistRecoverySession()
             return true
         } catch {
             cleanup()
@@ -147,6 +164,9 @@ class CustomMediaRecorder:NSObject {
         
         // Store the original file URL - this is what we'll always return
         originalFileURL = prevFileURL
+        sessionId = UUID().uuidString
+        sessionStartedAtMs = Self.nowMs()
+        currentDirectory = directory
         
         // Look for any existing temporary files from previous continuations
         findExistingTempSegments(forOriginalFile: prevFileURL)
@@ -179,6 +199,7 @@ class CustomMediaRecorder:NSObject {
                 
                 // Save segments list for recovery after app restart
                 saveTempSegmentsList()
+                persistRecoverySession()
                 
                 return true
             } else {
@@ -221,6 +242,7 @@ class CustomMediaRecorder:NSObject {
             UserDefaults.standard.set(segmentPaths, forKey: userDefaultsKey)
             UserDefaults.standard.synchronize()
             print("Saved \(segmentPaths.count) temp segments for recovery")
+            persistRecoverySession()
         }
     }
     
@@ -307,6 +329,7 @@ class CustomMediaRecorder:NSObject {
             
             // Clean up resources
             cleanup()
+            clearRecoverySession()
         }
     }
     
@@ -505,6 +528,9 @@ class CustomMediaRecorder:NSObject {
             originalRecordingSessionCategory = nil
             status = CurrentRecordingStatus.NONE
             currentTempRecordingPath = nil
+            sessionId = nil
+            sessionStartedAtMs = nil
+            currentDirectory = nil
         } catch {
             print("Error during cleanup: \(error)")
         }
@@ -522,6 +548,7 @@ class CustomMediaRecorder:NSObject {
         if(status == CurrentRecordingStatus.RECORDING) {
             audioRecorder.pause()
             status = CurrentRecordingStatus.PAUSED
+            persistRecoverySession()
             return true
         } else {
             return false
@@ -530,10 +557,14 @@ class CustomMediaRecorder:NSObject {
     
     public func resumeRecording() -> Bool {
         if(status == CurrentRecordingStatus.PAUSED) {
+            guard recordingSession != nil, audioRecorder != nil else {
+                return false
+            }
             do {
                 try recordingSession.setActive(true, options: .notifyOthersOnDeactivation)
                 audioRecorder.record() // It will continue from where it was paused
                 status = CurrentRecordingStatus.RECORDING
+                persistRecoverySession()
                 return true
             } catch {
                 print("Failed to resume recording: \(error)")
@@ -546,6 +577,23 @@ class CustomMediaRecorder:NSObject {
     
     public func getCurrentStatus() -> CurrentRecordingStatus {
         return status
+    }
+
+    public func getActiveRecordingSession() -> [String: Any]? {
+        if status != .NONE {
+            persistRecoverySession()
+            return buildRecoverySession(statusOverride: nil, interruptionReason: nil)
+        }
+
+        return Self.loadPersistedRecoverySession()
+    }
+
+    public func listRecoverableSessions() -> [[String: Any]] {
+        guard let session = Self.loadPersistedRecoverySession(),
+              Self.recoverySessionHasAudio(session) else {
+            return []
+        }
+        return [session]
     }
  
     public func removeRecording(fileUrl: URL) {
@@ -567,6 +615,7 @@ class CustomMediaRecorder:NSObject {
             if FileManager.default.fileExists(atPath: fileUrl.path) {
                 try FileManager.default.removeItem(atPath: fileUrl.path)
             }
+            clearRecoverySession()
         } catch let error {
             print("Error while removing file: \(error.localizedDescription)")
         }
@@ -574,6 +623,73 @@ class CustomMediaRecorder:NSObject {
 
     deinit {
         NotificationCenter.default.removeObserver(self)
+    }
+
+    private static func nowMs() -> Int {
+        return Int(Date().timeIntervalSince1970 * 1000)
+    }
+
+    private func buildRecoverySession(statusOverride: String?, interruptionReason: String?) -> [String: Any]? {
+        guard let fileURL = getOutputFile() else { return nil }
+        let sid = sessionId ?? fileURL.deletingPathExtension().lastPathComponent
+        let startedAt = sessionStartedAtMs ?? Self.nowMs()
+
+        var data: [String: Any] = [
+            "sessionId": sid,
+            "filePath": fileURL.absoluteString,
+            "status": statusOverride ?? status.rawValue,
+            "startedAt": startedAt,
+            "updatedAt": Self.nowMs(),
+            "platform": "ios",
+            "hasSegments": hasPersistedSegments(for: fileURL)
+        ]
+        if let directory = currentDirectory {
+            data["directory"] = directory
+        }
+        if let reason = interruptionReason {
+            data["interruptionReason"] = reason
+        }
+        return data
+    }
+
+    private func persistRecoverySession(statusOverride: String? = nil, interruptionReason: String? = nil) {
+        guard let data = buildRecoverySession(statusOverride: statusOverride, interruptionReason: interruptionReason) else {
+            return
+        }
+        UserDefaults.standard.set(data, forKey: Self.recoverySessionKey)
+        UserDefaults.standard.synchronize()
+    }
+
+    private func clearRecoverySession() {
+        UserDefaults.standard.removeObject(forKey: Self.recoverySessionKey)
+        UserDefaults.standard.synchronize()
+    }
+
+    private static func loadPersistedRecoverySession() -> [String: Any]? {
+        return UserDefaults.standard.dictionary(forKey: recoverySessionKey)
+    }
+
+    private static func recoverySessionHasAudio(_ session: [String: Any]) -> Bool {
+        guard let filePath = session["filePath"] as? String else { return false }
+        let fileURL: URL?
+        if filePath.hasPrefix("file://") {
+            fileURL = URL(string: filePath)
+        } else {
+            fileURL = URL(fileURLWithPath: filePath)
+        }
+        guard let url = fileURL else { return false }
+        if FileManager.default.fileExists(atPath: url.path) {
+            return true
+        }
+        return (session["hasSegments"] as? Bool) == true
+    }
+
+    private func hasPersistedSegments(for fileURL: URL) -> Bool {
+        guard let key = getTempSegmentsKey(forFile: fileURL),
+              let savedSegmentsPaths = UserDefaults.standard.array(forKey: key) as? [String] else {
+            return false
+        }
+        return savedSegmentsPaths.contains { FileManager.default.fileExists(atPath: $0) }
     }
 
     private func setupRecordingSession() -> Bool {
@@ -686,6 +802,9 @@ class CustomMediaRecorder:NSObject {
             // Clean up temp files
             self.cleanupTempFiles()
             self.clearTempSegmentsList()
+            if success {
+                self.clearRecoverySession()
+            }
             
             // Signal completion
             semaphore.signal()
@@ -758,7 +877,41 @@ extension CustomMediaRecorder:AVAudioRecorderDelegate {
     }
 
     @objc func handleMediaServicesReset(notification: Notification) {
-        tryResumeRecording()
+        // Apple recommends recreating audio objects after a media-services reset.
+        // Keep the persisted session recoverable, but require an explicit user retry.
+        if status == .RECORDING || status == .PAUSED {
+            persistRecoverySession(statusOverride: "INTERRUPTED", interruptionReason: "mediaServicesReset")
+            audioRecorder?.stop()
+            audioRecorder = nil
+            recordingSession = nil
+            status = .PAUSED
+        }
+    }
+
+    @objc func handleRouteChange(notification: Notification) {
+        guard let userInfo = notification.userInfo,
+              let reasonValue = userInfo[AVAudioSessionRouteChangeReasonKey] as? UInt,
+              let reason = AVAudioSession.RouteChangeReason(rawValue: reasonValue) else {
+            return
+        }
+
+        switch reason {
+        case .oldDeviceUnavailable, .newDeviceAvailable, .routeConfigurationChange:
+            if status == .RECORDING {
+                do {
+                    try recordingSession?.setCategory(.playAndRecord,
+                                                      mode: .default,
+                                                      options: [.allowBluetooth, .duckOthers, .defaultToSpeaker, .mixWithOthers])
+                    try recordingSession?.setActive(true, options: .notifyOthersOnDeactivation)
+                    persistRecoverySession()
+                } catch {
+                    let _ = pauseRecording()
+                    persistRecoverySession(statusOverride: "INTERRUPTED", interruptionReason: "routeChange")
+                }
+            }
+        default:
+            break
+        }
     }
 
     // Helper to check if we can record

--- a/ios/Plugin/VoiceRecorder.swift
+++ b/ios/Plugin/VoiceRecorder.swift
@@ -27,6 +27,17 @@ public class VoiceRecorder: CAPPlugin {
             name: AVAudioSession.routeChangeNotification,
             object: nil
         )
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleMediaServicesReset),
+            name: AVAudioSession.mediaServicesWereResetNotification,
+            object: AVAudioSession.sharedInstance()
+        )
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
     }
 
     @objc func canDeviceVoiceRecord(_ call: CAPPluginCall) {
@@ -48,6 +59,11 @@ public class VoiceRecorder: CAPPlugin {
     }
 
     @objc func startRecording(_ call: CAPPluginCall) {
+        if isStreaming {
+            call.reject("Audio streaming is already active")
+            return
+        }
+
         if(!doesUserGaveAudioRecordingPermission()) {
             call.reject(Messages.MISSING_PERMISSION)
             return
@@ -71,6 +87,11 @@ public class VoiceRecorder: CAPPlugin {
     }
 
     @objc func continueRecording(_ call: CAPPluginCall) {
+        if isStreaming {
+            call.reject("Audio streaming is already active")
+            return
+        }
+
         if(!doesUserGaveAudioRecordingPermission()) {
             call.reject(Messages.MISSING_PERMISSION)
             return
@@ -169,6 +190,18 @@ public class VoiceRecorder: CAPPlugin {
     @objc func getCurrentStatus(_ call: CAPPluginCall) {
         let status = customMediaRecorder.getCurrentStatus()
         call.resolve(ResponseGenerator.statusResponse(status))
+    }
+
+    @objc func getActiveRecordingSession(_ call: CAPPluginCall) {
+        if let session = customMediaRecorder.getActiveRecordingSession() {
+            call.resolve(ResponseGenerator.dataResponse(session))
+        } else {
+            call.resolve(ResponseGenerator.dataResponse(NSNull()))
+        }
+    }
+
+    @objc func listRecoverableRecordingSessions(_ call: CAPPluginCall) {
+        call.resolve(["sessions": customMediaRecorder.listRecoverableSessions()])
     }
 
     /**
@@ -305,6 +338,11 @@ public class VoiceRecorder: CAPPlugin {
 
     @objc func startAudioStream(_ call: CAPPluginCall) {
         if isStreaming {
+            call.resolve(ResponseGenerator.failResponse())
+            return
+        }
+
+        if customMediaRecorder.getCurrentStatus() != .NONE {
             call.resolve(ResponseGenerator.failResponse())
             return
         }
@@ -701,16 +739,35 @@ public class VoiceRecorder: CAPPlugin {
             
         case .ended:
             if isStreaming {
-                do {
-                    try AVAudioSession.sharedInstance().setActive(true)
-                    try audioEngine?.start()
-                } catch {
-                    print("VoiceRecorder: Failed to restart audio engine: \(error)")
+                guard let optionsValue = userInfo[AVAudioSessionInterruptionOptionKey] as? UInt else {
+                    return
+                }
+                let options = AVAudioSession.InterruptionOptions(rawValue: optionsValue)
+                if options.contains(.shouldResume) {
+                    reinstallEngineAndTap()
+                } else {
+                    notifyListeners("recordingStateChange", data: ["status": "INTERRUPTED", "reason": "audioSessionInterruption"])
                 }
             }
             
         @unknown default:
             break
+        }
+    }
+
+    @objc private func handleMediaServicesReset(notification: Notification) {
+        if isStreaming {
+            isStreaming = false
+            if let inputNode = inputNode {
+                inputNode.removeTap(onBus: 0)
+            }
+            audioEngine?.stop()
+            audioEngine = nil
+            inputNode = nil
+            persistSessionId = nil
+            persistSessionDir = nil
+            persistSeq = 0
+            notifyListeners("recordingStateChange", data: ["status": "INTERRUPTED", "reason": "mediaServicesReset"])
         }
     }
     

--- a/ios/Plugin/VoiceRecorder.swift
+++ b/ios/Plugin/VoiceRecorder.swift
@@ -292,6 +292,16 @@ public class VoiceRecorder: CAPPlugin {
     private var isStreaming = false
     private var streamingSampleRate: Double = 44100
     private var streamingChannels: UInt32 = 1
+    private var streamingBufferSize: UInt32 = 4096
+
+    // Live-chunk persistence state
+    private static let liveChunkRoot = "live-session-chunks"
+    private static let liveChunkSampleRate: Double = 16000
+    private static let liveChunkChannels: UInt32 = 1
+    private var persistSessionId: String?
+    private var persistSessionDir: URL?
+    private var persistSeq: Int = 0
+    private let persistSeqLock = NSLock()
 
     @objc func startAudioStream(_ call: CAPPluginCall) {
         if isStreaming {
@@ -310,33 +320,34 @@ public class VoiceRecorder: CAPPlugin {
         streamingSampleRate = call.getDouble("sampleRate") ?? 48000
         streamingChannels = UInt32(call.getInt("channels") ?? 1)
         let bufferSize = UInt32(call.getInt("bufferSize") ?? 4096)
+        streamingBufferSize = bufferSize
+
+        if let sid = call.getString("persistSessionId"), !sid.isEmpty {
+            guard Self.isValidSessionId(sid) else {
+                print("VoiceRecorder: Invalid persistSessionId (unsafe characters)")
+                call.resolve(ResponseGenerator.failResponse())
+                return
+            }
+            persistSessionId = sid
+            persistSessionDir = Self.ensureSessionDir(sid)
+            persistSeq = Self.nextSeq(for: persistSessionDir!)
+        } else {
+            persistSessionId = nil
+            persistSessionDir = nil
+            persistSeq = 0
+        }
 
         do {
             // Setup audio session for voice chat
             let audioSession = AVAudioSession.sharedInstance()
-            try audioSession.setCategory(.playAndRecord, 
-                                       mode: .voiceChat, 
+            try audioSession.setCategory(.playAndRecord,
+                                       mode: .voiceChat,
                                        options: [.defaultToSpeaker, .allowBluetoothA2DP, .mixWithOthers])
             try audioSession.setPreferredSampleRate(48000)
             try audioSession.setPreferredIOBufferDuration(0.005)
             try audioSession.setActive(true)
 
-            // Create audio engine
-            audioEngine = AVAudioEngine()
-            inputNode = audioEngine!.inputNode
-
-            // Configure input format using device's native format
-            let inputFormat = inputNode!.outputFormat(forBus: 0)
-            streamingSampleRate = inputFormat.sampleRate
-            streamingChannels = inputFormat.channelCount
-
-            // Install tap using the device's native format
-            inputNode!.installTap(onBus: 0, bufferSize: bufferSize, format: inputFormat) { [weak self] (buffer, time) in
-                self?.processAudioBuffer(buffer, time: time)
-            }
-
-            // Start audio engine
-            try audioEngine!.start()
+            try installEngineAndTap(bufferSize: bufferSize)
             isStreaming = true
 
             call.resolve(ResponseGenerator.successResponse())
@@ -346,22 +357,51 @@ public class VoiceRecorder: CAPPlugin {
         }
     }
 
+    private func installEngineAndTap(bufferSize: UInt32) throws {
+        audioEngine = AVAudioEngine()
+        inputNode = audioEngine!.inputNode
+
+        let inputFormat = inputNode!.outputFormat(forBus: 0)
+        streamingSampleRate = inputFormat.sampleRate
+        streamingChannels = inputFormat.channelCount
+
+        inputNode!.installTap(onBus: 0, bufferSize: bufferSize, format: inputFormat) { [weak self] (buffer, time) in
+            self?.processAudioBuffer(buffer, time: time)
+        }
+
+        try audioEngine!.start()
+    }
+
+    private func reinstallEngineAndTap() {
+        guard isStreaming else { return }
+        do {
+            if let inputNode = inputNode {
+                inputNode.removeTap(onBus: 0)
+            }
+            audioEngine?.stop()
+            audioEngine = nil
+            inputNode = nil
+            try AVAudioSession.sharedInstance().setActive(true)
+            try installEngineAndTap(bufferSize: streamingBufferSize)
+        } catch {
+            print("VoiceRecorder: Failed to reinstall engine/tap: \(error)")
+        }
+    }
+
     private var bufferCount = 0
     private var silentBufferCount = 0
-    
+
     private func processAudioBuffer(_ buffer: AVAudioPCMBuffer, time: AVAudioTime) {
-        guard let channelData = buffer.floatChannelData else { 
-            return 
+        guard let channelData = buffer.floatChannelData else {
+            return
         }
-        
+
         let frameLength = Int(buffer.frameLength)
         let audioData = Array(UnsafeBufferPointer(start: channelData[0], count: frameLength))
-        
-        // Calculate audio level for monitoring
+
         let avgLevel = audioData.reduce(0) { $0 + abs($1) } / Float(audioData.count)
         bufferCount += 1
-        
-        // Monitor audio levels periodically
+
         if bufferCount % 100 == 0 {
             if avgLevel < 0.001 {
                 silentBufferCount += 1
@@ -373,13 +413,42 @@ public class VoiceRecorder: CAPPlugin {
             }
         }
 
-        // Send data to JavaScript
-        let data: [String: Any] = [
-            "audioData": audioData,
-            "sampleRate": streamingSampleRate,
-            "timestamp": Date().timeIntervalSince1970 * 1000, // milliseconds
-            "channels": streamingChannels
+        // If persistence is active, downsample + PCM16 + write BEFORE emitting to JS.
+        var persistedSeq: Int? = nil
+        var persistedPath: String? = nil
+        var emittedSamples: [Float] = audioData
+        var emittedSampleRate: Double = streamingSampleRate
+        var emittedChannels: UInt32 = streamingChannels
+        var downsampled = false
+
+        if let sessionDir = persistSessionDir {
+            let pcm16k = Self.downsampleToMono16k(samples: audioData, inRate: streamingSampleRate)
+            persistSeqLock.lock()
+            let seq = persistSeq
+            persistSeq += 1
+            persistSeqLock.unlock()
+            do {
+                let path = try Self.writeChunkAtomic(dir: sessionDir, seq: seq, pcm16: pcm16k)
+                persistedSeq = seq
+                persistedPath = path.path
+            } catch {
+                print("VoiceRecorder: Failed to persist chunk: \(error)")
+            }
+            emittedSamples = pcm16k.map { Float($0) / 32768.0 }
+            emittedSampleRate = Self.liveChunkSampleRate
+            emittedChannels = Self.liveChunkChannels
+            downsampled = true
+        }
+
+        var data: [String: Any] = [
+            "audioData": emittedSamples,
+            "sampleRate": emittedSampleRate,
+            "timestamp": Date().timeIntervalSince1970 * 1000,
+            "channels": emittedChannels,
+            "downsampled16kMono": downsampled
         ]
+        if let seq = persistedSeq { data["seq"] = seq }
+        if let path = persistedPath { data["path"] = path }
 
         notifyListeners("audioData", data: data)
     }
@@ -387,21 +456,24 @@ public class VoiceRecorder: CAPPlugin {
     @objc func stopAudioStream(_ call: CAPPluginCall) {
         do {
             isStreaming = false
-            
-            // Reset counters
+
             bufferCount = 0
             silentBufferCount = 0
-            
+
             if let inputNode = inputNode {
                 inputNode.removeTap(onBus: 0)
             }
-            
+
             audioEngine?.stop()
             audioEngine = nil
             inputNode = nil
 
             let audioSession = AVAudioSession.sharedInstance()
             try audioSession.setActive(false)
+
+            persistSessionId = nil
+            persistSessionDir = nil
+            persistSeq = 0
 
             call.resolve(ResponseGenerator.successResponse())
         } catch {
@@ -413,7 +485,205 @@ public class VoiceRecorder: CAPPlugin {
         let result = ["status": isStreaming ? "STREAMING" : "STOPPED"]
         call.resolve(result)
     }
-    
+
+    // MARK: - Live-chunk plugin methods
+
+    @objc func listLiveChunkSessions(_ call: CAPPluginCall) {
+        let root = Self.liveChunkRootDir()
+        var ids: [String] = []
+        if let contents = try? FileManager.default.contentsOfDirectory(at: root, includingPropertiesForKeys: [.isDirectoryKey], options: [.skipsHiddenFiles]) {
+            for url in contents {
+                var isDir: ObjCBool = false
+                if FileManager.default.fileExists(atPath: url.path, isDirectory: &isDir), isDir.boolValue {
+                    ids.append(url.lastPathComponent)
+                }
+            }
+        }
+        call.resolve(["sessions": ids])
+    }
+
+    @objc func listLiveChunks(_ call: CAPPluginCall) {
+        guard let sid = call.getString("sessionId"), Self.isValidSessionId(sid) else {
+            call.reject("Invalid sessionId")
+            return
+        }
+        let dir = Self.liveChunkRootDir().appendingPathComponent(sid, isDirectory: true)
+        var chunks: [[String: Any]] = []
+        if let contents = try? FileManager.default.contentsOfDirectory(at: dir, includingPropertiesForKeys: [.fileSizeKey], options: [.skipsHiddenFiles]) {
+            let sorted = contents.sorted { $0.lastPathComponent < $1.lastPathComponent }
+            for url in sorted {
+                guard url.pathExtension == "pcm" else { continue }
+                let name = url.deletingPathExtension().lastPathComponent
+                guard let seq = Int(name) else { continue }
+                let size = (try? FileManager.default.attributesOfItem(atPath: url.path)[.size] as? Int) ?? 0
+                chunks.append([
+                    "seq": seq,
+                    "path": url.path,
+                    "size": size ?? 0
+                ])
+            }
+        }
+        call.resolve(["chunks": chunks])
+    }
+
+    @objc func readLiveChunk(_ call: CAPPluginCall) {
+        guard let sid = call.getString("sessionId"), Self.isValidSessionId(sid),
+              let seq = call.getInt("seq") else {
+            call.reject("Invalid sessionId or seq")
+            return
+        }
+        let fileUrl = Self.liveChunkRootDir()
+            .appendingPathComponent(sid, isDirectory: true)
+            .appendingPathComponent(String(format: "%06d.pcm", seq))
+        guard FileManager.default.fileExists(atPath: fileUrl.path) else {
+            call.reject("Chunk not found")
+            return
+        }
+        do {
+            let data = try Data(contentsOf: fileUrl)
+            call.resolve([
+                "data": data.base64EncodedString(),
+                "size": data.count
+            ])
+        } catch {
+            call.reject("Failed to read chunk: \(error.localizedDescription)")
+        }
+    }
+
+    @objc func deleteLiveChunk(_ call: CAPPluginCall) {
+        guard let sid = call.getString("sessionId"), Self.isValidSessionId(sid),
+              let seq = call.getInt("seq") else {
+            call.reject("Invalid sessionId or seq")
+            return
+        }
+        let fileUrl = Self.liveChunkRootDir()
+            .appendingPathComponent(sid, isDirectory: true)
+            .appendingPathComponent(String(format: "%06d.pcm", seq))
+        if FileManager.default.fileExists(atPath: fileUrl.path) {
+            do {
+                try FileManager.default.removeItem(at: fileUrl)
+            } catch {
+                call.resolve(ResponseGenerator.failResponse())
+                return
+            }
+        }
+        call.resolve(ResponseGenerator.successResponse())
+    }
+
+    @objc func deleteLiveChunkSession(_ call: CAPPluginCall) {
+        guard let sid = call.getString("sessionId"), Self.isValidSessionId(sid) else {
+            call.reject("Invalid sessionId")
+            return
+        }
+        let dir = Self.liveChunkRootDir().appendingPathComponent(sid, isDirectory: true)
+        if FileManager.default.fileExists(atPath: dir.path) {
+            do {
+                try FileManager.default.removeItem(at: dir)
+            } catch {
+                call.resolve(ResponseGenerator.failResponse())
+                return
+            }
+        }
+        call.resolve(ResponseGenerator.successResponse())
+    }
+
+    @objc func getLiveChunkSessionInfo(_ call: CAPPluginCall) {
+        guard let sid = call.getString("sessionId"), Self.isValidSessionId(sid) else {
+            call.reject("Invalid sessionId")
+            return
+        }
+        let dir = Self.liveChunkRootDir().appendingPathComponent(sid, isDirectory: true)
+        var totalBytes = 0
+        var count = 0
+        var firstSeq = -1
+        var lastSeq = -1
+        if let contents = try? FileManager.default.contentsOfDirectory(at: dir, includingPropertiesForKeys: [.fileSizeKey], options: [.skipsHiddenFiles]) {
+            for url in contents {
+                guard url.pathExtension == "pcm" else { continue }
+                let name = url.deletingPathExtension().lastPathComponent
+                guard let seq = Int(name) else { continue }
+                let size = (try? FileManager.default.attributesOfItem(atPath: url.path)[.size] as? Int) ?? 0
+                totalBytes += size ?? 0
+                count += 1
+                if firstSeq == -1 || seq < firstSeq { firstSeq = seq }
+                if seq > lastSeq { lastSeq = seq }
+            }
+        }
+        call.resolve([
+            "totalBytes": totalBytes,
+            "count": count,
+            "firstSeq": firstSeq,
+            "lastSeq": lastSeq,
+            "dir": dir.path
+        ])
+    }
+
+    @objc func assembleLiveChunksToWav(_ call: CAPPluginCall) {
+        guard let sid = call.getString("sessionId"), Self.isValidSessionId(sid),
+              let outputPath = call.getString("outputPath"), !outputPath.isEmpty else {
+            call.reject("Invalid sessionId or outputPath")
+            return
+        }
+        let sampleRate = UInt32(call.getInt("sampleRate") ?? Int(Self.liveChunkSampleRate))
+        let channels = UInt32(call.getInt("channels") ?? Int(Self.liveChunkChannels))
+
+        let dir = Self.liveChunkRootDir().appendingPathComponent(sid, isDirectory: true)
+        guard FileManager.default.fileExists(atPath: dir.path) else {
+            call.reject("Session directory not found")
+            return
+        }
+
+        let fileManager = FileManager.default
+        var chunkUrls: [URL] = []
+        if let contents = try? fileManager.contentsOfDirectory(at: dir, includingPropertiesForKeys: nil, options: [.skipsHiddenFiles]) {
+            chunkUrls = contents.filter { $0.pathExtension == "pcm" }
+                                .sorted { $0.lastPathComponent < $1.lastPathComponent }
+        }
+
+        var dataBytes: UInt64 = 0
+        for url in chunkUrls {
+            let size = (try? fileManager.attributesOfItem(atPath: url.path)[.size] as? Int) ?? 0
+            dataBytes += UInt64(size ?? 0)
+        }
+        if dataBytes == 0 {
+            call.reject("No chunks to assemble")
+            return
+        }
+
+        let outURL = URL(fileURLWithPath: outputPath)
+        try? fileManager.createDirectory(at: outURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        if fileManager.fileExists(atPath: outURL.path) {
+            try? fileManager.removeItem(at: outURL)
+        }
+        fileManager.createFile(atPath: outURL.path, contents: nil)
+        guard let out = try? FileHandle(forWritingTo: outURL) else {
+            call.reject("Cannot open output for writing")
+            return
+        }
+        defer { try? out.close() }
+
+        out.write(Self.buildWavHeader(sampleRate: sampleRate, channels: channels, dataBytes: UInt32(min(UInt64(UInt32.max), dataBytes))))
+        for url in chunkUrls {
+            if let input = try? FileHandle(forReadingFrom: url) {
+                while true {
+                    let chunk = input.readData(ofLength: 64 * 1024)
+                    if chunk.isEmpty { break }
+                    out.write(chunk)
+                }
+                try? input.close()
+            }
+        }
+        try? out.synchronize()
+
+        let msDuration = (Double(dataBytes) / (Double(sampleRate) * Double(channels) * 2.0)) * 1000.0
+        let finalSize = (try? fileManager.attributesOfItem(atPath: outURL.path)[.size] as? Int) ?? 0
+        call.resolve([
+            "filePath": outURL.path,
+            "msDuration": Int(msDuration),
+            "size": finalSize ?? 0
+        ])
+    }
+
     // MARK: - Audio Session Interruption Handling
     
     @objc private func handleAudioSessionInterruption(notification: Notification) {
@@ -450,15 +720,129 @@ public class VoiceRecorder: CAPPlugin {
               let reason = AVAudioSession.RouteChangeReason(rawValue: reasonValue) else {
             return
         }
-        
+
         switch reason {
-        case .newDeviceAvailable, .oldDeviceUnavailable:
-            // Audio route changed - could restart engine if needed
-            break
-            
+        case .oldDeviceUnavailable, .newDeviceAvailable, .routeConfigurationChange:
+            // Reinstall the tap so we continue capturing from the correct input.
+            reinstallEngineAndTap()
         default:
             break
         }
+    }
+
+    // MARK: - Live-chunk helpers
+
+    private static func isValidSessionId(_ id: String) -> Bool {
+        if id.isEmpty || id.count > 128 { return false }
+        for c in id {
+            let isOk = c.isASCII && (c.isLetter || c.isNumber || c == "-" || c == "_")
+            if !isOk { return false }
+        }
+        return true
+    }
+
+    private static func applicationSupportDir() -> URL {
+        let url = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        if !FileManager.default.fileExists(atPath: url.path) {
+            try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        }
+        return url
+    }
+
+    private static func liveChunkRootDir() -> URL {
+        let url = applicationSupportDir().appendingPathComponent(liveChunkRoot, isDirectory: true)
+        if !FileManager.default.fileExists(atPath: url.path) {
+            try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        }
+        return url
+    }
+
+    private static func ensureSessionDir(_ sessionId: String) -> URL {
+        let url = liveChunkRootDir().appendingPathComponent(sessionId, isDirectory: true)
+        if !FileManager.default.fileExists(atPath: url.path) {
+            try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        }
+        return url
+    }
+
+    private static func nextSeq(for dir: URL) -> Int {
+        guard let contents = try? FileManager.default.contentsOfDirectory(at: dir, includingPropertiesForKeys: nil, options: [.skipsHiddenFiles]) else {
+            return 0
+        }
+        var maxSeq = -1
+        for url in contents where url.pathExtension == "pcm" {
+            let name = url.deletingPathExtension().lastPathComponent
+            if let s = Int(name), s > maxSeq { maxSeq = s }
+        }
+        return maxSeq + 1
+    }
+
+    private static func writeChunkAtomic(dir: URL, seq: Int, pcm16: [Int16]) throws -> URL {
+        let filename = String(format: "%06d.pcm", seq)
+        let finalUrl = dir.appendingPathComponent(filename)
+        var data = Data(capacity: pcm16.count * 2)
+        for s in pcm16 {
+            var le = s.littleEndian
+            withUnsafeBytes(of: &le) { data.append(contentsOf: $0) }
+        }
+        try data.write(to: finalUrl, options: [.atomic])
+        return finalUrl
+    }
+
+    private static func downsampleToMono16k(samples: [Float], inRate: Double) -> [Int16] {
+        if abs(inRate - liveChunkSampleRate) < 0.5 {
+            return samples.map { Int16(max(-32768, min(32767, Int($0 * 32767.0)))) }
+        }
+        let ratio = inRate / liveChunkSampleRate
+        // Integer-step decimation with box filter if clean multiple
+        if ratio >= 2 && abs(ratio - ratio.rounded()) < 0.01 {
+            let step = Int(ratio.rounded())
+            let outLen = samples.count / step
+            var out = [Int16](); out.reserveCapacity(outLen)
+            var i = 0
+            while i + step <= samples.count {
+                var acc: Float = 0
+                for k in 0..<step { acc += samples[i + k] }
+                let avg = acc / Float(step)
+                out.append(Int16(max(-32768, min(32767, Int(avg * 32767.0)))))
+                i += step
+            }
+            return out
+        }
+        // Linear resample
+        let outLen = Int(Double(samples.count) / ratio)
+        var out = [Int16](); out.reserveCapacity(outLen)
+        for i in 0..<outLen {
+            let srcPos = Double(i) * ratio
+            let srcIdx = Int(srcPos)
+            let frac = srcPos - Double(srcIdx)
+            let a = srcIdx < samples.count ? Double(samples[srcIdx]) : 0
+            let b = srcIdx + 1 < samples.count ? Double(samples[srcIdx + 1]) : a
+            let v = a + (b - a) * frac
+            out.append(Int16(max(-32768, min(32767, Int(v * 32767.0)))))
+        }
+        return out
+    }
+
+    private static func buildWavHeader(sampleRate: UInt32, channels: UInt32, dataBytes: UInt32) -> Data {
+        var header = Data()
+        func writeStr(_ s: String) { header.append(contentsOf: s.utf8) }
+        func writeU32(_ v: UInt32) { var le = v.littleEndian; withUnsafeBytes(of: &le) { header.append(contentsOf: $0) } }
+        func writeU16(_ v: UInt16) { var le = v.littleEndian; withUnsafeBytes(of: &le) { header.append(contentsOf: $0) } }
+        writeStr("RIFF")
+        writeU32(36 + dataBytes)
+        writeStr("WAVE")
+        writeStr("fmt ")
+        writeU32(16)
+        writeU16(1) // PCM
+        writeU16(UInt16(channels))
+        writeU32(sampleRate)
+        writeU32(sampleRate * channels * 2)
+        writeU16(UInt16(channels * 2))
+        writeU16(16)
+        writeStr("data")
+        writeU32(dataBytes)
+        return header
     }
 }
 

--- a/ios/Plugin/VoiceRecorderPlugin.m
+++ b/ios/Plugin/VoiceRecorderPlugin.m
@@ -19,4 +19,11 @@ CAP_PLUGIN(VoiceRecorder, "VoiceRecorder",
            CAP_PLUGIN_METHOD(stopAudioStream, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(getStreamingStatus, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(listRecordingFiles, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(listLiveChunkSessions, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(listLiveChunks, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(readLiveChunk, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(deleteLiveChunk, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(deleteLiveChunkSession, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(getLiveChunkSessionInfo, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(assembleLiveChunksToWav, CAPPluginReturnPromise);
 )

--- a/ios/Plugin/VoiceRecorderPlugin.m
+++ b/ios/Plugin/VoiceRecorderPlugin.m
@@ -13,6 +13,8 @@ CAP_PLUGIN(VoiceRecorder, "VoiceRecorder",
            CAP_PLUGIN_METHOD(pauseRecording, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(resumeRecording, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(getCurrentStatus, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(getActiveRecordingSession, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(listRecoverableRecordingSessions, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(getRecordingInfo, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(finalizeRecording, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(startAudioStream, CAPPluginReturnPromise);

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,20 +31,24 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.26.2",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.28.5",
         "js-tokens": "^4.0.0",
-        "picocolors": "^1.0.0"
+        "picocolors": "^1.1.1"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.25.9",
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -158,30 +162,6 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
-    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/@eslint/config-array/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/@eslint/config-helpers": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
@@ -209,20 +189,20 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.3.tgz",
-      "integrity": "sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.4.tgz",
+      "integrity": "sha512-4h4MVF8pmBsncB60r0wSJiIeUKTSD4m7FmTFThG8RHlsg9ajqckLm9OraguFGZE4vVdpiI1Q4+hFnisopmG6gQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ajv": "^6.12.4",
+        "ajv": "^6.14.0",
         "debug": "^4.3.2",
         "espree": "^10.0.1",
         "globals": "^14.0.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
         "js-yaml": "^4.1.1",
-        "minimatch": "^3.1.2",
+        "minimatch": "^3.1.3",
         "strip-json-comments": "^3.1.1"
       },
       "engines": {
@@ -232,34 +212,20 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+    "node_modules/@eslint/eslintrc/node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
       "engines": {
-        "node": "*"
+        "node": ">= 4"
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.39.2",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.2.tgz",
-      "integrity": "sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA==",
+      "version": "9.39.3",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.3.tgz",
+      "integrity": "sha512-1B1VkCq6FuUNlQvlBYb+1jDu/gV297TIs/OeiaSR9l1H27SVW55ONE1e1Vp16NqP683+xEGzxYtv4XCiDPaQiw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -304,35 +270,23 @@
       }
     },
     "node_modules/@humanfs/node": {
-      "version": "0.16.6",
-      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.6.tgz",
-      "integrity": "sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==",
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
+      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@humanfs/core": "^0.19.1",
-        "@humanwhocodes/retry": "^0.3.0"
+        "@humanwhocodes/retry": "^0.4.0"
       },
       "engines": {
         "node": ">=18.18.0"
       }
     },
-    "node_modules/@humanfs/node/node_modules/@humanwhocodes/retry": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.1.tgz",
-      "integrity": "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=18.18"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/nzakas"
-      }
-    },
     "node_modules/@humanwhocodes/module-importer": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -344,9 +298,9 @@
       }
     },
     "node_modules/@humanwhocodes/retry": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.2.tgz",
-      "integrity": "sha512-xeO57FpIu4p1Ri3Jq/EXq4ClRm86dVF2z/+kvFnyqVYRavTZmaFaUBbWCOuuTh0o/g7DSsk6kc2vrS4Vl5oPOQ==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -359,6 +313,8 @@
     },
     "node_modules/@ionic/cli-framework-output": {
       "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/@ionic/cli-framework-output/-/cli-framework-output-2.2.8.tgz",
+      "integrity": "sha512-TshtaFQsovB4NWRBydbNFawql6yul7d5bMiW1WYYf17hd99V6xdDdk3vtF51bw6sLkxON3bDQpWsnUc9/hVo3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -389,6 +345,8 @@
     },
     "node_modules/@ionic/utils-array": {
       "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@ionic/utils-array/-/utils-array-2.1.6.tgz",
+      "integrity": "sha512-0JZ1Zkp3wURnv8oq6Qt7fMPo5MpjbLoUoa9Bu2Q4PJuSDWM8H8gwF3dQO7VTeUj3/0o1IB1wGkFWZZYgUXZMUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -401,6 +359,8 @@
     },
     "node_modules/@ionic/utils-fs": {
       "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@ionic/utils-fs/-/utils-fs-3.1.7.tgz",
+      "integrity": "sha512-2EknRvMVfhnyhL1VhFkSLa5gOcycK91VnjfrTB0kbqkTFCOXyXgVLI5whzq7SLrgD9t1aqos3lMMQyVzaQ5gVA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -415,6 +375,8 @@
     },
     "node_modules/@ionic/utils-fs/node_modules/fs-extra": {
       "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -429,6 +391,8 @@
     },
     "node_modules/@ionic/utils-object": {
       "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@ionic/utils-object/-/utils-object-2.1.6.tgz",
+      "integrity": "sha512-vCl7sl6JjBHFw99CuAqHljYJpcE88YaH2ZW4ELiC/Zwxl5tiwn4kbdP/gxi2OT3MQb1vOtgAmSNRtusvgxI8ww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -441,6 +405,8 @@
     },
     "node_modules/@ionic/utils-process": {
       "version": "2.1.12",
+      "resolved": "https://registry.npmjs.org/@ionic/utils-process/-/utils-process-2.1.12.tgz",
+      "integrity": "sha512-Jqkgyq7zBs/v/J3YvKtQQiIcxfJyplPgECMWgdO0E1fKrrH8EF0QGHNJ9mJCn6PYe2UtHNS8JJf5G21e09DfYg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -457,6 +423,8 @@
     },
     "node_modules/@ionic/utils-stream": {
       "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@ionic/utils-stream/-/utils-stream-3.1.7.tgz",
+      "integrity": "sha512-eSELBE7NWNFIHTbTC2jiMvh1ABKGIpGdUIvARsNPMNQhxJB3wpwdiVnoBoTYp+5a6UUIww4Kpg7v6S7iTctH1w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -469,6 +437,8 @@
     },
     "node_modules/@ionic/utils-subprocess": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@ionic/utils-subprocess/-/utils-subprocess-3.0.1.tgz",
+      "integrity": "sha512-cT4te3AQQPeIM9WCwIg8ohroJ8TjsYaMb2G4ZEgv9YzeDqHZ4JpeIKqG2SoaA3GmVQ3sOfhPM6Ox9sxphV/d1A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -487,6 +457,8 @@
     },
     "node_modules/@ionic/utils-terminal": {
       "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@ionic/utils-terminal/-/utils-terminal-2.3.5.tgz",
+      "integrity": "sha512-3cKScz9Jx2/Pr9ijj1OzGlBDfcmx7OMVBt4+P1uRR0SSW4cm1/y3Mo4OY3lfkuaYifMNBW8Wz6lQHbs1bihr7A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -504,16 +476,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@isaacs/cliui": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
-      "integrity": "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@isaacs/fs-minipass": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
@@ -528,9 +490,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.34.8",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.34.8.tgz",
-      "integrity": "sha512-q217OSE8DTp8AFHuNHXo0Y86e1wtlfVrXiAlwkIvGRQv9zbc6mE3sjIVfwI8sYUyNxwOg0j/Vm1RKM04JcWLJw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
+      "integrity": "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==",
       "cpu": [
         "arm"
       ],
@@ -542,9 +504,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.34.8",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.34.8.tgz",
-      "integrity": "sha512-Gigjz7mNWaOL9wCggvoK3jEIUUbGul656opstjaUSGC3eT0BM7PofdAJaBfPFWWkXNVAXbaQtC99OCg4sJv70Q==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz",
+      "integrity": "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==",
       "cpu": [
         "arm64"
       ],
@@ -556,9 +518,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.34.8",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.34.8.tgz",
-      "integrity": "sha512-02rVdZ5tgdUNRxIUrFdcMBZQoaPMrxtwSb+/hOfBdqkatYHR3lZ2A2EGyHq2sGOd0Owk80oV3snlDASC24He3Q==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz",
+      "integrity": "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==",
       "cpu": [
         "arm64"
       ],
@@ -570,9 +532,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.34.8",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.34.8.tgz",
-      "integrity": "sha512-qIP/elwR/tq/dYRx3lgwK31jkZvMiD6qUtOycLhTzCvrjbZ3LjQnEM9rNhSGpbLXVJYQ3rq39A6Re0h9tU2ynw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
+      "integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
       "cpu": [
         "x64"
       ],
@@ -584,9 +546,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.34.8",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.34.8.tgz",
-      "integrity": "sha512-IQNVXL9iY6NniYbTaOKdrlVP3XIqazBgJOVkddzJlqnCpRi/yAeSOa8PLcECFSQochzqApIOE1GHNu3pCz+BDA==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz",
+      "integrity": "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==",
       "cpu": [
         "arm64"
       ],
@@ -598,9 +560,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.34.8",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.34.8.tgz",
-      "integrity": "sha512-TYXcHghgnCqYFiE3FT5QwXtOZqDj5GmaFNTNt3jNC+vh22dc/ukG2cG+pi75QO4kACohZzidsq7yKTKwq/Jq7Q==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz",
+      "integrity": "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==",
       "cpu": [
         "x64"
       ],
@@ -612,9 +574,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.34.8",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.34.8.tgz",
-      "integrity": "sha512-A4iphFGNkWRd+5m3VIGuqHnG3MVnqKe7Al57u9mwgbyZ2/xF9Jio72MaY7xxh+Y87VAHmGQr73qoKL9HPbXj1g==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz",
+      "integrity": "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==",
       "cpu": [
         "arm"
       ],
@@ -626,9 +588,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.34.8",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.34.8.tgz",
-      "integrity": "sha512-S0lqKLfTm5u+QTxlFiAnb2J/2dgQqRy/XvziPtDd1rKZFXHTyYLoVL58M/XFwDI01AQCDIevGLbQrMAtdyanpA==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz",
+      "integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
       "cpu": [
         "arm"
       ],
@@ -640,9 +602,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.34.8",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.34.8.tgz",
-      "integrity": "sha512-jpz9YOuPiSkL4G4pqKrus0pn9aYwpImGkosRKwNi+sJSkz+WU3anZe6hi73StLOQdfXYXC7hUfsQlTnjMd3s1A==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
+      "integrity": "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==",
       "cpu": [
         "arm64"
       ],
@@ -654,9 +616,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.34.8",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.34.8.tgz",
-      "integrity": "sha512-KdSfaROOUJXgTVxJNAZ3KwkRc5nggDk+06P6lgi1HLv1hskgvxHUKZ4xtwHkVYJ1Rep4GNo+uEfycCRRxht7+Q==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz",
+      "integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
       "cpu": [
         "arm64"
       ],
@@ -667,10 +629,10 @@
         "linux"
       ]
     },
-    "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-      "version": "4.34.8",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.34.8.tgz",
-      "integrity": "sha512-NyF4gcxwkMFRjgXBM6g2lkT58OWztZvw5KkV2K0qqSnUEqCVcqdh2jN4gQrTn/YUpAcNKyFHfoOZEer9nwo6uQ==",
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz",
+      "integrity": "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==",
       "cpu": [
         "loong64"
       ],
@@ -681,10 +643,38 @@
         "linux"
       ]
     },
-    "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-      "version": "4.34.8",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.34.8.tgz",
-      "integrity": "sha512-LMJc999GkhGvktHU85zNTDImZVUCJ1z/MbAJTnviiWmmjyckP5aQsHtcujMjpNdMZPT2rQEDBlJfubhs3jsMfw==",
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz",
+      "integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz",
+      "integrity": "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz",
+      "integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
       "cpu": [
         "ppc64"
       ],
@@ -696,9 +686,23 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.34.8",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.34.8.tgz",
-      "integrity": "sha512-xAQCAHPj8nJq1PI3z8CIZzXuXCstquz7cIOL73HHdXiRcKk8Ywwqtx2wrIy23EcTn4aZ2fLJNBB8d0tQENPCmw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz",
+      "integrity": "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz",
+      "integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
       "cpu": [
         "riscv64"
       ],
@@ -710,9 +714,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.34.8",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.34.8.tgz",
-      "integrity": "sha512-DdePVk1NDEuc3fOe3dPPTb+rjMtuFw89gw6gVWxQFAuEqqSdDKnrwzZHrUYdac7A7dXl9Q2Vflxpme15gUWQFA==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz",
+      "integrity": "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==",
       "cpu": [
         "s390x"
       ],
@@ -724,9 +728,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.34.8",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.34.8.tgz",
-      "integrity": "sha512-8y7ED8gjxITUltTUEJLQdgpbPh1sUQ0kMTmufRF/Ns5tI9TNMNlhWtmPKKHCU0SilX+3MJkZ0zERYYGIVBYHIA==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
       "cpu": [
         "x64"
       ],
@@ -738,9 +742,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.34.8",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.34.8.tgz",
-      "integrity": "sha512-SCXcP0ZpGFIe7Ge+McxY5zKxiEI5ra+GT3QRxL0pMMtxPfpyLAKleZODi1zdRHkz5/BhueUrYtYVgubqe9JBNQ==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz",
+      "integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
       "cpu": [
         "x64"
       ],
@@ -751,10 +755,38 @@
         "linux"
       ]
     },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz",
+      "integrity": "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz",
+      "integrity": "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.34.8",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.34.8.tgz",
-      "integrity": "sha512-YHYsgzZgFJzTRbth4h7Or0m5O74Yda+hLin0irAIobkLQFRQd1qWmnoVfwmKm9TXIZVAD0nZ+GEb2ICicLyCnQ==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
+      "integrity": "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==",
       "cpu": [
         "arm64"
       ],
@@ -766,9 +798,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.34.8",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.34.8.tgz",
-      "integrity": "sha512-r3NRQrXkHr4uWy5TOjTpTYojR9XmF0j/RYgKCef+Ag46FWUTltm5ziticv8LdNsDMehjJ543x/+TJAek/xBA2w==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz",
+      "integrity": "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==",
       "cpu": [
         "ia32"
       ],
@@ -779,10 +811,24 @@
         "win32"
       ]
     },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.34.8",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.34.8.tgz",
-      "integrity": "sha512-U0FaE5O1BCpZSeE6gBl3c5ObhePQSfk9vDRToMmTkbhCOgW4jqvtS5LGyQ76L1fH8sM0keRp4uDTsbjiUyjk0g==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
+      "integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
       "cpu": [
         "x64"
       ],
@@ -794,12 +840,16 @@
       ]
     },
     "node_modules/@types/estree": {
-      "version": "1.0.6",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/fs-extra": {
       "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-8.1.5.tgz",
+      "integrity": "sha512-0dzKcwO+S8s2kuF5Z9oUWatQJj5Uq/iqphEtE3GQJVRRYm/tD1LglU2UnXi2A8jLq5umkGouOXOR9y0n613ZwQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -814,30 +864,34 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.13.1",
+      "version": "25.3.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.1.tgz",
+      "integrity": "sha512-hj9YIJimBCipHVfHKRMnvmHg+wfhKc0o4mTtXh9pKBjC8TLJzz0nzGmLi5UJsYAUgSvXFHgb0V2oY10DUFtImw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.20.0"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@types/slice-ansi": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/slice-ansi/-/slice-ansi-4.0.0.tgz",
+      "integrity": "sha512-+OpjSaq85gvlZAYINyzKpLeiFkSC4EsC6IIiT6v6TLSU5k5U83fHGj9Lel8oKEXM0HqgrMVCjXPDPVICtxF7EQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.56.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.56.0.tgz",
-      "integrity": "sha512-lRyPDLzNCuae71A3t9NEINBiTn7swyOhvUj3MyUOxb8x6g6vPEFoOU+ZRmGMusNC3X3YMhqMIX7i8ShqhT74Pw==",
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.56.1.tgz",
+      "integrity": "sha512-Jz9ZztpB37dNC+HU2HI28Bs9QXpzCz+y/twHOwhyrIRdbuVDxSytJNDl6z/aAKlaRIwC7y8wJdkBv7FxYGgi0A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.56.0",
-        "@typescript-eslint/type-utils": "8.56.0",
-        "@typescript-eslint/utils": "8.56.0",
-        "@typescript-eslint/visitor-keys": "8.56.0",
+        "@typescript-eslint/scope-manager": "8.56.1",
+        "@typescript-eslint/type-utils": "8.56.1",
+        "@typescript-eslint/utils": "8.56.1",
+        "@typescript-eslint/visitor-keys": "8.56.1",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.4.0"
@@ -850,33 +904,23 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.56.0",
+        "@typescript-eslint/parser": "^8.56.1",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
-    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.56.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.56.0.tgz",
-      "integrity": "sha512-IgSWvLobTDOjnaxAfDTIHaECbkNlAlKv2j5SjpB2v7QHKv1FIfjwMy8FsDbVfDX/KjmCmYICcw7uGaXLhtsLNg==",
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.56.1.tgz",
+      "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.56.0",
-        "@typescript-eslint/types": "8.56.0",
-        "@typescript-eslint/typescript-estree": "8.56.0",
-        "@typescript-eslint/visitor-keys": "8.56.0",
+        "@typescript-eslint/scope-manager": "8.56.1",
+        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/typescript-estree": "8.56.1",
+        "@typescript-eslint/visitor-keys": "8.56.1",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -892,14 +936,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.56.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.56.0.tgz",
-      "integrity": "sha512-M3rnyL1vIQOMeWxTWIW096/TtVP+8W3p/XnaFflhmcFp+U4zlxUxWj4XwNs6HbDeTtN4yun0GNTTDBw/SvufKg==",
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.56.1.tgz",
+      "integrity": "sha512-TAdqQTzHNNvlVFfR+hu2PDJrURiwKsUvxFn1M0h95BB8ah5jejas08jUWG4dBA68jDMI988IvtfdAI53JzEHOQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.56.0",
-        "@typescript-eslint/types": "^8.56.0",
+        "@typescript-eslint/tsconfig-utils": "^8.56.1",
+        "@typescript-eslint/types": "^8.56.1",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -914,14 +958,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.56.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.56.0.tgz",
-      "integrity": "sha512-7UiO/XwMHquH+ZzfVCfUNkIXlp/yQjjnlYUyYz7pfvlK3/EyyN6BK+emDmGNyQLBtLGaYrTAI6KOw8tFucWL2w==",
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.56.1.tgz",
+      "integrity": "sha512-YAi4VDKcIZp0O4tz/haYKhmIDZFEUPOreKbfdAN3SzUDMcPhJ8QI99xQXqX+HoUVq8cs85eRKnD+rne2UAnj2w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.56.0",
-        "@typescript-eslint/visitor-keys": "8.56.0"
+        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/visitor-keys": "8.56.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -932,9 +976,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.56.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.56.0.tgz",
-      "integrity": "sha512-bSJoIIt4o3lKXD3xmDh9chZcjCz5Lk8xS7Rxn+6l5/pKrDpkCwtQNQQwZ2qRPk7TkUYhrq3WPIHXOXlbXP0itg==",
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.56.1.tgz",
+      "integrity": "sha512-qOtCYzKEeyr3aR9f28mPJqBty7+DBqsdd63eO0yyDwc6vgThj2UjWfJIcsFeSucYydqcuudMOprZ+x1SpF3ZuQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -949,15 +993,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.56.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.56.0.tgz",
-      "integrity": "sha512-qX2L3HWOU2nuDs6GzglBeuFXviDODreS58tLY/BALPC7iu3Fa+J7EOTwnX9PdNBxUI7Uh0ntP0YWGnxCkXzmfA==",
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.56.1.tgz",
+      "integrity": "sha512-yB/7dxi7MgTtGhZdaHCemf7PuwrHMenHjmzgUW1aJpO+bBU43OycnM3Wn+DdvDO/8zzA9HlhaJ0AUGuvri4oGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.56.0",
-        "@typescript-eslint/typescript-estree": "8.56.0",
-        "@typescript-eslint/utils": "8.56.0",
+        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/typescript-estree": "8.56.1",
+        "@typescript-eslint/utils": "8.56.1",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.4.0"
       },
@@ -974,9 +1018,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.56.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.56.0.tgz",
-      "integrity": "sha512-DBsLPs3GsWhX5HylbP9HNG15U0bnwut55Lx12bHB9MpXxQ+R5GC8MwQe+N1UFXxAeQDvEsEDY6ZYwX03K7Z6HQ==",
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.56.1.tgz",
+      "integrity": "sha512-dbMkdIUkIkchgGDIv7KLUpa0Mda4IYjo4IAMJUZ+3xNoUXxMsk9YtKpTHSChRS85o+H9ftm51gsK1dZReY9CVw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -988,18 +1032,18 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.56.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.56.0.tgz",
-      "integrity": "sha512-ex1nTUMWrseMltXUHmR2GAQ4d+WjkZCT4f+4bVsps8QEdh0vlBsaCokKTPlnqBFqqGaxilDNJG7b8dolW2m43Q==",
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.56.1.tgz",
+      "integrity": "sha512-qzUL1qgalIvKWAf9C1HpvBjif+Vm6rcT5wZd4VoMb9+Km3iS3Cv9DY6dMRMDtPnwRAFyAi7YXJpTIEXLvdfPxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.56.0",
-        "@typescript-eslint/tsconfig-utils": "8.56.0",
-        "@typescript-eslint/types": "8.56.0",
-        "@typescript-eslint/visitor-keys": "8.56.0",
+        "@typescript-eslint/project-service": "8.56.1",
+        "@typescript-eslint/tsconfig-utils": "8.56.1",
+        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/visitor-keys": "8.56.1",
         "debug": "^4.4.3",
-        "minimatch": "^9.0.5",
+        "minimatch": "^10.2.2",
         "semver": "^7.7.3",
         "tinyglobby": "^0.2.15",
         "ts-api-utils": "^2.4.0"
@@ -1016,16 +1060,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.56.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.56.0.tgz",
-      "integrity": "sha512-RZ3Qsmi2nFGsS+n+kjLAYDPVlrzf7UhTffrDIKr+h2yzAlYP/y5ZulU0yeDEPItos2Ph46JAL5P/On3pe7kDIQ==",
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.56.1.tgz",
+      "integrity": "sha512-HPAVNIME3tABJ61siYlHzSWCGtOoeP2RTIaHXFMPqjrQKCGB9OgUVdiNgH7TJS2JNIQ5qQ4RsAUDuGaGme/KOA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.56.0",
-        "@typescript-eslint/types": "8.56.0",
-        "@typescript-eslint/typescript-estree": "8.56.0"
+        "@typescript-eslint/scope-manager": "8.56.1",
+        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/typescript-estree": "8.56.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1040,13 +1084,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.56.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.56.0.tgz",
-      "integrity": "sha512-q+SL+b+05Ud6LbEE35qe4A99P+htKTKVbyiNEe45eCbJFyh/HVK9QXwlrbz+Q4L8SOW4roxSVwXYj4DMBT7Ieg==",
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.56.1.tgz",
+      "integrity": "sha512-KiROIzYdEV85YygXw6BI/Dx4fnBlFQu6Mq4QE4MOH9fFnhohw6wX/OAvDY2/C+ut0I3RSPKenvZJIVYqJNkhEw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.56.0",
+        "@typescript-eslint/types": "8.56.1",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -1058,9 +1102,9 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.0.tgz",
-      "integrity": "sha512-A0XeIi7CXU7nPlfHS9loMYEKxUaONu/hTEzHTGba9Huu94Cq1hPivf+DE5erJozZOky0LfvXAyrV/tcswpLI0Q==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -1081,9 +1125,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -1104,9 +1148,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1122,6 +1166,8 @@
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1130,6 +1176,8 @@
     },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1144,11 +1192,15 @@
     },
     "node_modules/argparse": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/astral-regex": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1157,6 +1209,8 @@
     },
     "node_modules/at-least-node": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -1165,6 +1219,8 @@
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
     },
@@ -1234,6 +1290,8 @@
     },
     "node_modules/callsites": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1242,6 +1300,8 @@
     },
     "node_modules/chalk": {
       "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1267,6 +1327,8 @@
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1278,24 +1340,52 @@
     },
     "node_modules/color-name": {
       "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/commander": {
       "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
+    "node_modules/cosmiconfig": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
+      "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "env-paths": "^2.2.1",
+        "import-fresh": "^3.3.0",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.9.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1327,11 +1417,15 @@
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/define-lazy-prop": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1353,11 +1447,15 @@
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/env-paths": {
       "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1365,7 +1463,9 @@
       }
     },
     "node_modules/error-ex": {
-      "version": "1.3.2",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1374,6 +1474,8 @@
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1384,9 +1486,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.39.2",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.2.tgz",
-      "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
+      "version": "9.39.3",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.3.tgz",
+      "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1396,7 +1498,7 @@
         "@eslint/config-helpers": "^0.4.2",
         "@eslint/core": "^0.17.0",
         "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.39.2",
+        "@eslint/js": "9.39.3",
         "@eslint/plugin-kit": "^0.4.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
@@ -1462,6 +1564,8 @@
     },
     "node_modules/eslint-visitor-keys": {
       "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -1469,17 +1573,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
       }
     },
     "node_modules/eslint/node_modules/eslint-visitor-keys": {
@@ -1495,15 +1588,14 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/eslint/node_modules/minimatch": {
-      "version": "3.1.2",
+    "node_modules/eslint/node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
       "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
+      "license": "MIT",
       "engines": {
-        "node": "*"
+        "node": ">= 4"
       }
     },
     "node_modules/espree": {
@@ -1538,7 +1630,9 @@
       }
     },
     "node_modules/esquery": {
-      "version": "1.6.0",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -1563,6 +1657,8 @@
     },
     "node_modules/estraverse": {
       "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -1595,6 +1691,8 @@
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
     },
@@ -1641,6 +1739,8 @@
     },
     "node_modules/find-up": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1675,38 +1775,10 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/foreground-child": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
-      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "cross-spawn": "^7.0.6",
-        "signal-exit": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/foreground-child/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/fs-extra": {
-      "version": "11.3.0",
+      "version": "11.3.3",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.3.tgz",
+      "integrity": "sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1718,9 +1790,19 @@
         "node": ">=14.14"
       }
     },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "dev": true,
+      "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1731,25 +1813,21 @@
       }
     },
     "node_modules/glob": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
-      "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
-      "license": "BlueOak-1.0.0",
+      "license": "ISC",
       "dependencies": {
-        "foreground-child": "^3.3.1",
-        "jackspeak": "^4.1.1",
-        "minimatch": "^10.1.1",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^2.0.0"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -1757,6 +1835,8 @@
     },
     "node_modules/glob-parent": {
       "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -1764,48 +1844,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/glob/node_modules/balanced-match": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.2.tgz",
-      "integrity": "sha512-x0K50QvKQ97fdEz2kPehIerj+YTeptKF9hyYkKf6egnwmMWAkADiO0QCzSp0R5xN8FTZgYaBfSaue46Ej62nMg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "jackspeak": "^4.2.3"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/glob/node_modules/brace-expansion": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.2.tgz",
-      "integrity": "sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/glob/node_modules/minimatch": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.1.tgz",
-      "integrity": "sha512-MClCe8IL5nRRmawL6ib/eT4oLyeKMGCghibcDWK+J0hh0Q8kqSdia6BvbRMVk6mPa6WqUa5uR2oxt6C5jd533A==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/globals": {
@@ -1823,11 +1861,15 @@
     },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1841,7 +1883,9 @@
       "license": "ISC"
     },
     "node_modules/ignore": {
-      "version": "5.3.2",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1850,6 +1894,8 @@
     },
     "node_modules/import-fresh": {
       "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1865,10 +1911,24 @@
     },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "node_modules/inherits": {
@@ -1890,11 +1950,15 @@
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/is-docker": {
       "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -1909,6 +1973,8 @@
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1917,6 +1983,8 @@
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1925,6 +1993,8 @@
     },
     "node_modules/is-glob": {
       "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1936,6 +2006,8 @@
     },
     "node_modules/is-wsl": {
       "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1947,27 +2019,15 @@
     },
     "node_modules/isexe": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/jackspeak": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
-      "integrity": "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/cliui": "^9.0.0"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -1993,6 +2053,8 @@
     },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true,
       "license": "MIT"
     },
@@ -2005,11 +2067,15 @@
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/jsonfile": {
-      "version": "6.1.0",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2031,6 +2097,8 @@
     },
     "node_modules/kleur": {
       "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2039,6 +2107,8 @@
     },
     "node_modules/levn": {
       "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2051,11 +2121,15 @@
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2070,37 +2144,30 @@
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/lru-cache": {
-      "version": "11.0.2",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
     "node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.2.tgz",
+      "integrity": "sha512-bNH9mmM9qsJ2X4r2Nat1B//1dJVcn3+iBLa3IgqJ7EbGaDNepL9QSHOxN4ng33s52VMMhhIfgCYDk3C4ZmlDAg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+        "node": ">=10"
       }
     },
     "node_modules/minipass": {
-      "version": "7.1.2",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
@@ -2120,6 +2187,8 @@
     },
     "node_modules/ms": {
       "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
     },
@@ -2151,11 +2220,25 @@
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
     "node_modules/open": {
       "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
+      "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2172,6 +2255,8 @@
     },
     "node_modules/optionator": {
       "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2188,6 +2273,8 @@
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2202,6 +2289,8 @@
     },
     "node_modules/p-locate": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2216,11 +2305,15 @@
     },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "dev": true,
       "license": "BlueOak-1.0.0"
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2232,6 +2325,8 @@
     },
     "node_modules/parse-json": {
       "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2249,6 +2344,8 @@
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2257,25 +2354,12 @@
     },
     "node_modules/path-key": {
       "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/path-scurry": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^11.0.0",
-        "minipass": "^7.1.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/pend": {
@@ -2287,6 +2371,8 @@
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
       "license": "ISC"
     },
@@ -2320,6 +2406,8 @@
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2327,9 +2415,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.1.tgz",
-      "integrity": "sha512-hPpFQvHwL3Qv5AdRvBFMhnKo4tYxp0ReXiPn2bxkiohEX6mBeBwEpBSQTkD458RaaDKQMYSp4hX4UtfUTA5wDw==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
+      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -2344,6 +2432,8 @@
     },
     "node_modules/prompts": {
       "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2356,6 +2446,8 @@
     },
     "node_modules/prompts/node_modules/kleur": {
       "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2389,6 +2481,8 @@
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2396,14 +2490,14 @@
       }
     },
     "node_modules/rimraf": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.0.1.tgz",
-      "integrity": "sha512-9dkvaxAsk/xNXSJzMgFqqMCuFgt2+KsOFek3TMLfo8NCPfWpBmqwyNn5Y+NX56QUYfCtsyhF3ayiboEoUmJk/A==",
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.1.3.tgz",
+      "integrity": "sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "glob": "^11.0.0",
-        "package-json-from-dist": "^1.0.0"
+        "glob": "^13.0.3",
+        "package-json-from-dist": "^1.0.1"
       },
       "bin": {
         "rimraf": "dist/esm/bin.mjs"
@@ -2416,13 +2510,13 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.34.8",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.34.8.tgz",
-      "integrity": "sha512-489gTVMzAYdiZHFVA/ig/iYFllCcWFHMvUHI1rpFmkoUtRlQxqh6/yiNqnYibjMZ2b/+FUQwldG+aLsEt6bglQ==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
+      "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/estree": "1.0.6"
+        "@types/estree": "1.0.8"
       },
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -2432,25 +2526,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.34.8",
-        "@rollup/rollup-android-arm64": "4.34.8",
-        "@rollup/rollup-darwin-arm64": "4.34.8",
-        "@rollup/rollup-darwin-x64": "4.34.8",
-        "@rollup/rollup-freebsd-arm64": "4.34.8",
-        "@rollup/rollup-freebsd-x64": "4.34.8",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.34.8",
-        "@rollup/rollup-linux-arm-musleabihf": "4.34.8",
-        "@rollup/rollup-linux-arm64-gnu": "4.34.8",
-        "@rollup/rollup-linux-arm64-musl": "4.34.8",
-        "@rollup/rollup-linux-loongarch64-gnu": "4.34.8",
-        "@rollup/rollup-linux-powerpc64le-gnu": "4.34.8",
-        "@rollup/rollup-linux-riscv64-gnu": "4.34.8",
-        "@rollup/rollup-linux-s390x-gnu": "4.34.8",
-        "@rollup/rollup-linux-x64-gnu": "4.34.8",
-        "@rollup/rollup-linux-x64-musl": "4.34.8",
-        "@rollup/rollup-win32-arm64-msvc": "4.34.8",
-        "@rollup/rollup-win32-ia32-msvc": "4.34.8",
-        "@rollup/rollup-win32-x64-msvc": "4.34.8",
+        "@rollup/rollup-android-arm-eabi": "4.59.0",
+        "@rollup/rollup-android-arm64": "4.59.0",
+        "@rollup/rollup-darwin-arm64": "4.59.0",
+        "@rollup/rollup-darwin-x64": "4.59.0",
+        "@rollup/rollup-freebsd-arm64": "4.59.0",
+        "@rollup/rollup-freebsd-x64": "4.59.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.59.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.59.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.59.0",
+        "@rollup/rollup-linux-arm64-musl": "4.59.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.59.0",
+        "@rollup/rollup-linux-loong64-musl": "4.59.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.59.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.59.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.59.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.59.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-musl": "4.59.0",
+        "@rollup/rollup-openbsd-x64": "4.59.0",
+        "@rollup/rollup-openharmony-arm64": "4.59.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.59.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.59.0",
+        "@rollup/rollup-win32-x64-gnu": "4.59.0",
+        "@rollup/rollup-win32-x64-msvc": "4.59.0",
         "fsevents": "~2.3.2"
       }
     },
@@ -2477,6 +2577,8 @@
     },
     "node_modules/sax": {
       "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.1.4.tgz",
+      "integrity": "sha512-5f3k2PbGGp+YtKJjOItpg3P99IMD84E4HOvcfleTb5joCHNXYLsR9yWFPOYGgaeMPDubQILTCMdsFb2OMeOjtg==",
       "dev": true,
       "license": "ISC"
     },
@@ -2495,6 +2597,8 @@
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2506,6 +2610,8 @@
     },
     "node_modules/shebang-regex": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2514,16 +2620,22 @@
     },
     "node_modules/signal-exit": {
       "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/slice-ansi": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2560,6 +2672,8 @@
     },
     "node_modules/string-width": {
       "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2573,6 +2687,8 @@
     },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2597,6 +2713,8 @@
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2620,31 +2738,6 @@
       },
       "bin": {
         "node-swiftlint": "bin.js"
-      }
-    },
-    "node_modules/swiftlint/node_modules/cosmiconfig": {
-      "version": "9.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "env-paths": "^2.2.1",
-        "import-fresh": "^3.3.0",
-        "js-yaml": "^4.1.0",
-        "parse-json": "^5.2.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/d-fischer"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.9.5"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
       }
     },
     "node_modules/tar": {
@@ -2693,6 +2786,8 @@
     },
     "node_modules/tree-kill": {
       "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -2714,11 +2809,15 @@
     },
     "node_modules/tslib": {
       "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
       "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2743,12 +2842,16 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.20.0",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/universalify": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2757,6 +2860,8 @@
     },
     "node_modules/untildify": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
+      "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2782,6 +2887,8 @@
     },
     "node_modules/which": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -2796,6 +2903,8 @@
     },
     "node_modules/word-wrap": {
       "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2804,6 +2913,8 @@
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2818,8 +2929,17 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/xml2js": {
       "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2832,6 +2952,8 @@
     },
     "node_modules/xml2js/node_modules/xmlbuilder": {
       "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2871,6 +2993,8 @@
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "capacitor-voice-rec",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Capacitor plugin for voice recording",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",
@@ -48,7 +48,7 @@
     "swiftlint": "node-swiftlint",
     "docgen": "docgen --api VoiceRecorderPlugin --output-readme README.md --output-json dist/docs.json",
     "build": "npm run clean && tsc && rollup -c rollup.config.mjs",
-    "clean": "rimraf ./dist",
+    "clean": "node -e \"require('fs').rmSync('./dist',{recursive:true,force:true})\"",
     "watch": "tsc --watch",
     "prepublishOnly": "npm run build",
     "prepare": "npm run build"
@@ -66,7 +66,6 @@
     "@typescript-eslint/eslint-plugin": "^8.56.0",
     "eslint": "^9.39.2",
     "prettier": "^3.5.1",
-    "rimraf": "^6.0.1",
     "rollup": "^4.34.8",
     "swiftlint": "^2.0.0",
     "typescript": "^5.9.3"

--- a/src/VoiceRecorderImpl.ts
+++ b/src/VoiceRecorderImpl.ts
@@ -483,7 +483,7 @@ export class VoiceRecorderImpl {
     this.pendingResult = neverResolvingPromise();
   }
 
-  private notifyStateChange(status: 'RECORDING' | 'PAUSED' | 'NONE') {
+  private notifyStateChange(status: CurrentRecordingStatus['status']) {
     if (this.onStateChange) {
       this.onStateChange({ status });
     }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -24,7 +24,28 @@ export interface GenericResponse {
 }
 
 export interface CurrentRecordingStatus {
-  status: 'RECORDING' | 'PAUSED' | 'NONE';
+  status: 'RECORDING' | 'PAUSED' | 'NONE' | 'INTERRUPTED';
+  reason?: string;
+}
+
+export interface RecordingSessionInfo {
+  sessionId: string;
+  filePath: string;
+  status: 'RECORDING' | 'PAUSED' | 'NONE' | 'INTERRUPTED';
+  startedAt: number;
+  updatedAt: number;
+  platform: 'ios' | 'android' | 'web';
+  hasSegments?: boolean;
+  directory?: string;
+  interruptionReason?: string;
+}
+
+export interface ActiveRecordingSessionResult {
+  value: RecordingSessionInfo | null;
+}
+
+export interface RecoverableRecordingSessionsResult {
+  sessions: RecordingSessionInfo[];
 }
 
 export interface AudioStreamOptions {
@@ -147,6 +168,17 @@ export interface VoiceRecorderPlugin {
   resumeRecording(): Promise<GenericResponse>;
 
   getCurrentStatus(): Promise<CurrentRecordingStatus>;
+
+  /**
+   * Returns the native-owned active/recoverable recording session, if one exists.
+   * This is the bridge-recovery source of truth after a WebView reload.
+   */
+  getActiveRecordingSession(): Promise<ActiveRecordingSessionResult>;
+
+  /**
+   * Lists native sessions with durable audio or segments that can be saved/resumed.
+   */
+  listRecoverableRecordingSessions(): Promise<RecoverableRecordingSessionsResult>;
   
   /**
    * Get information about a recording file without having to continue/stop it

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -28,9 +28,26 @@ export interface CurrentRecordingStatus {
 }
 
 export interface AudioStreamOptions {
-  sampleRate?: number; // Default: 44100
+  sampleRate?: number; // Default: 48000 on native, 44100 on web
   channels?: number; // Default: 1 (mono)
   bufferSize?: number; // Default: 4096
+
+  /**
+   * Android-only: keep the app alive while streaming by running a foreground service
+   * with a persistent notification. Required for long-running offline sessions that
+   * must survive backgrounding / screen-lock.
+   */
+  useForegroundService?: boolean;
+
+  /**
+   * When set, the native plugin writes every captured PCM chunk to disk (16-bit LE
+   * mono PCM at 16 kHz) in a per-session directory, atomically (tmp + rename),
+   * before notifying JS via `audioData`. The `seq` and `path` of each chunk are
+   * included on the event payload. This persists through JS bridge / WebView crashes.
+   *
+   * The value is used verbatim as the session directory name and must be filesystem-safe.
+   */
+  persistSessionId?: string;
 }
 
 export interface AudioDataEvent {
@@ -38,6 +55,19 @@ export interface AudioDataEvent {
   sampleRate: number;
   timestamp: number;
   channels: number;
+
+  /** Monotonic, zero-based sequence number within a session. Present when `persistSessionId` is set. */
+  seq?: number;
+
+  /** Absolute native path to the persisted chunk file. Present when `persistSessionId` is set. */
+  path?: string;
+
+  /**
+   * When the native plugin performed downsampling to 16 kHz 16-bit PCM for persistence,
+   * this flag is true and `audioData` is already in that format (normalized Float32 for
+   * compatibility with existing JS consumers). JS should skip its own downsample path.
+   */
+  downsampled16kMono?: boolean;
 }
 
 export interface StreamingStatus {
@@ -55,6 +85,35 @@ export interface RecordingFileInfo {
 
 export interface ListRecordingFilesResult {
   files: RecordingFileInfo[];
+}
+
+export interface LiveChunkInfo {
+  seq: number;
+  path: string;
+  size: number;
+}
+
+export interface ListLiveChunkSessionsResult {
+  sessions: string[];
+}
+
+export interface ListLiveChunksResult {
+  chunks: LiveChunkInfo[];
+}
+
+export interface ReadLiveChunkResult {
+  /** Base64-encoded PCM bytes for the requested chunk. */
+  data: Base64String;
+  size: number;
+}
+
+export interface LiveChunkSessionInfo {
+  totalBytes: number;
+  count: number;
+  firstSeq: number;
+  lastSeq: number;
+  /** Absolute native path to the session directory. */
+  dir: string;
 }
 
 export interface VoiceRecorderPlugin {
@@ -127,4 +186,51 @@ export interface VoiceRecorderPlugin {
    * List all recording files on disk for orphan detection
    */
   listRecordingFiles(options?: { directory?: string }): Promise<ListRecordingFilesResult>;
+
+  // --- Live-session chunk persistence (native-owned, survives bridge/webview crashes) ---
+
+  /**
+   * List all live-chunk session directories currently present on disk. Used on app
+   * boot to detect orphaned or recoverable sessions.
+   */
+  listLiveChunkSessions(): Promise<ListLiveChunkSessionsResult>;
+
+  /**
+   * List all chunks for a given live session, sorted by sequence number ascending.
+   * Ignores any `.tmp` or otherwise partial files.
+   */
+  listLiveChunks(options: { sessionId: string }): Promise<ListLiveChunksResult>;
+
+  /**
+   * Read a single chunk's bytes as base64.
+   */
+  readLiveChunk(options: { sessionId: string; seq: number }): Promise<ReadLiveChunkResult>;
+
+  /**
+   * Delete a single chunk by sequence number (called after a successful WS ACK).
+   */
+  deleteLiveChunk(options: { sessionId: string; seq: number }): Promise<GenericResponse>;
+
+  /**
+   * Delete an entire session directory (used after successful finalization or dismiss).
+   */
+  deleteLiveChunkSession(options: { sessionId: string }): Promise<GenericResponse>;
+
+  /**
+   * Lightweight totals for a session (bytes, chunk count, seq range). Used by UI to
+   * show progress and by the manager to check disk usage.
+   */
+  getLiveChunkSessionInfo(options: { sessionId: string }): Promise<LiveChunkSessionInfo>;
+
+  /**
+   * Assemble all chunks for a session into a single WAV file at the given output path.
+   * Runs entirely in native code to avoid loading the full recording into JS memory.
+   * Returns the absolute path of the WAV and its duration in ms.
+   */
+  assembleLiveChunksToWav(options: {
+    sessionId: string;
+    outputPath: string;
+    sampleRate?: number; // default 16000
+    channels?: number;   // default 1
+  }): Promise<{ filePath: string; msDuration: number; size: number }>;
 }

--- a/src/web.ts
+++ b/src/web.ts
@@ -12,7 +12,38 @@ import type {
   AudioDataEvent,
   StreamingStatus,
   ListRecordingFilesResult,
+  ListLiveChunkSessionsResult,
+  ListLiveChunksResult,
+  ReadLiveChunkResult,
+  LiveChunkSessionInfo,
 } from './definitions';
+
+// IndexedDB-backed live-chunk storage for web parity. Keyed by (sessionId, seq).
+// Native platforms own the authoritative implementation; web is best-effort for
+// development and debugging.
+const LIVE_DB_NAME = 'CapacitorVoiceRecLiveChunks';
+const LIVE_STORE = 'chunks';
+
+async function openLiveChunkDb(): Promise<IDBDatabase> {
+  // Dynamically import `idb` only when needed to keep non-streaming web usage slim.
+  const { openDB } = await import('idb');
+  return (await openDB(LIVE_DB_NAME, 1, {
+    upgrade(db) {
+      const store = db.createObjectStore(LIVE_STORE, { keyPath: ['sessionId', 'seq'] });
+      store.createIndex('bySession', 'sessionId');
+    },
+  })) as unknown as IDBDatabase;
+}
+
+function base64FromArrayBuffer(buf: ArrayBuffer): string {
+  const bytes = new Uint8Array(buf);
+  let binary = '';
+  const chunkSize = 0x8000;
+  for (let i = 0; i < bytes.length; i += chunkSize) {
+    binary += String.fromCharCode.apply(null, Array.from(bytes.subarray(i, i + chunkSize)) as unknown as number[]);
+  }
+  return btoa(binary);
+}
 
 export class VoiceRecorderWeb extends WebPlugin implements VoiceRecorderPlugin {
   private voiceRecorderInstance = new VoiceRecorderImpl();
@@ -23,6 +54,8 @@ export class VoiceRecorderWeb extends WebPlugin implements VoiceRecorderPlugin {
   private audioWorkletNode?: AudioWorkletNode;
   private isStreaming = false;
   private streamingOptions?: AudioStreamOptions;
+  private persistSessionId?: string;
+  private streamingSeq = 0;
 
   constructor() {
     super();
@@ -83,92 +116,81 @@ export class VoiceRecorderWeb extends WebPlugin implements VoiceRecorderPlugin {
   public getCurrentStatus(): Promise<CurrentRecordingStatus> {
     return Promise.resolve(this.currentStatus);
   }
-  
-  /**
-   * Get information about a recording file without having to continue/stop it
-   * This method is a web implementation fallback
-   */
+
   public async getRecordingInfo(options: { filePath: string }): Promise<RecordingInfoData> {
     return this.voiceRecorderInstance.getRecordingInfo(options.filePath);
   }
-  
-  /**
-   * Finalize a recording by merging any temporary segments without continuing/stopping it
-   * This method is a web implementation fallback
-   */
+
   public async finalizeRecording(options: { filePath: string }): Promise<RecordingData> {
     return this.voiceRecorderInstance.finalizeRecording(options.filePath);
   }
-  
-  /**
-   * Start streaming audio data in real-time for voice chat applications
-   */
+
   public async startAudioStream(options: AudioStreamOptions = {}): Promise<GenericResponse> {
     try {
       if (this.isStreaming) {
         return { value: false };
       }
 
-      // Set default options
       this.streamingOptions = {
         sampleRate: options.sampleRate || 44100,
         channels: options.channels || 1,
-        bufferSize: options.bufferSize || 4096
+        bufferSize: options.bufferSize || 4096,
       };
+      this.persistSessionId = options.persistSessionId;
+      this.streamingSeq = 0;
 
-      // Request microphone access
       const constraints = {
         audio: {
           sampleRate: this.streamingOptions.sampleRate,
           channelCount: this.streamingOptions.channels,
           echoCancellation: true,
           noiseSuppression: true,
-          autoGainControl: true
-        }
+          autoGainControl: true,
+        },
       };
 
       this.mediaStream = await navigator.mediaDevices.getUserMedia(constraints);
-      
-      // Create audio context
-      this.audioContext = new AudioContext({ 
-        sampleRate: this.streamingOptions.sampleRate 
-      });
-      
-      // Load AudioWorklet processor
+
+      this.audioContext = new AudioContext({ sampleRate: this.streamingOptions.sampleRate });
+
       try {
         await this.audioContext.audioWorklet.addModule('/assets/audio-stream-processor.js');
       } catch (error) {
         console.warn('AudioWorklet not available, falling back to ScriptProcessor');
         return this.startAudioStreamFallback();
       }
-      
-      // Create audio worklet node
+
       const source = this.audioContext.createMediaStreamSource(this.mediaStream);
       this.audioWorkletNode = new AudioWorkletNode(this.audioContext, 'audio-stream-processor', {
         processorOptions: {
           bufferSize: this.streamingOptions.bufferSize,
           sampleRate: this.streamingOptions.sampleRate,
-          channels: this.streamingOptions.channels
-        }
+          channels: this.streamingOptions.channels,
+        },
       });
 
-      // Listen for audio data from worklet
-      this.audioWorkletNode.port.onmessage = (event) => {
+      this.audioWorkletNode.port.onmessage = async (event) => {
         const { audioData, timestamp, sampleRate, channels } = event.data;
+        const seq = this.streamingSeq++;
+        let path: string | undefined;
+        if (this.persistSessionId) {
+          path = await this.persistWebChunk(this.persistSessionId, seq, audioData as Float32Array);
+        }
         this.notifyListeners('audioData', {
           audioData: new Float32Array(audioData),
           sampleRate: sampleRate || this.streamingOptions?.sampleRate || 44100,
           timestamp,
-          channels: channels || this.streamingOptions?.channels || 1
+          channels: channels || this.streamingOptions?.channels || 1,
+          seq,
+          path,
+          downsampled16kMono: false,
         } as AudioDataEvent);
       };
 
-      // Connect the audio graph
       source.connect(this.audioWorkletNode);
-      
+
       this.isStreaming = true;
       return { value: true };
-      
     } catch (error) {
       console.error('Failed to start audio stream:', error);
       await this.cleanupStreaming();
@@ -176,36 +198,40 @@ export class VoiceRecorderWeb extends WebPlugin implements VoiceRecorderPlugin {
     }
   }
 
-  /**
-   * Fallback implementation using ScriptProcessor for older browsers
-   */
   private async startAudioStreamFallback(): Promise<GenericResponse> {
     try {
       const source = this.audioContext!.createMediaStreamSource(this.mediaStream!);
       const processor = this.audioContext!.createScriptProcessor(
-        this.streamingOptions!.bufferSize, 
-        this.streamingOptions!.channels, 
-        this.streamingOptions!.channels
+        this.streamingOptions!.bufferSize,
+        this.streamingOptions!.channels,
+        this.streamingOptions!.channels,
       );
 
-      processor.onaudioprocess = (event) => {
+      processor.onaudioprocess = async (event) => {
         const inputBuffer = event.inputBuffer;
         const audioData = inputBuffer.getChannelData(0);
-        
+        const seq = this.streamingSeq++;
+        let path: string | undefined;
+        if (this.persistSessionId) {
+          path = await this.persistWebChunk(this.persistSessionId, seq, audioData);
+        }
+
         this.notifyListeners('audioData', {
           audioData: new Float32Array(audioData),
           sampleRate: this.streamingOptions!.sampleRate!,
           timestamp: Date.now(),
-          channels: this.streamingOptions!.channels!
+          channels: this.streamingOptions!.channels!,
+          seq,
+          path,
+          downsampled16kMono: false,
         } as AudioDataEvent);
       };
 
       source.connect(processor);
       processor.connect(this.audioContext!.destination);
-      
+
       this.isStreaming = true;
       return { value: true };
-      
     } catch (error) {
       console.error('Fallback audio streaming failed:', error);
       await this.cleanupStreaming();
@@ -213,43 +239,183 @@ export class VoiceRecorderWeb extends WebPlugin implements VoiceRecorderPlugin {
     }
   }
 
-  /**
-   * Stop streaming audio data
-   */
   public async stopAudioStream(): Promise<GenericResponse> {
     try {
       if (!this.isStreaming) {
         return { value: false };
       }
-
       await this.cleanupStreaming();
       return { value: true };
-      
     } catch (error) {
       console.error('Failed to stop audio stream:', error);
       return { value: false };
     }
   }
 
-  /**
-   * Get current streaming status
-   */
   public async getStreamingStatus(): Promise<StreamingStatus> {
     return { status: this.isStreaming ? 'STREAMING' : 'STOPPED' };
   }
 
-  /**
-   * List recording files on disk — returns empty on web (no orphan concept)
-   */
   public async listRecordingFiles(): Promise<ListRecordingFilesResult> {
     return { files: [] };
   }
 
-  /**
-   * Clean up streaming resources
-   */
+  // --- Live-chunk persistence (IndexedDB-backed on web) ---
+
+  public async listLiveChunkSessions(): Promise<ListLiveChunkSessionsResult> {
+    try {
+      const db = await openLiveChunkDb();
+      const tx = (db as any).transaction(LIVE_STORE, 'readonly');
+      const ids = new Set<string>();
+      let cursor = await tx.store.openCursor();
+      while (cursor) {
+        const key = cursor.key as [string, number];
+        ids.add(key[0]);
+        cursor = await cursor.continue();
+      }
+      return { sessions: Array.from(ids) };
+    } catch (e) {
+      console.warn('listLiveChunkSessions failed on web', e);
+      return { sessions: [] };
+    }
+  }
+
+  public async listLiveChunks(options: { sessionId: string }): Promise<ListLiveChunksResult> {
+    try {
+      const db = await openLiveChunkDb();
+      const tx = (db as any).transaction(LIVE_STORE, 'readonly');
+      const chunks: { seq: number; path: string; size: number }[] = [];
+      let cursor = await tx.store.openCursor();
+      while (cursor) {
+        const [sid, seq] = cursor.key as [string, number];
+        if (sid === options.sessionId) {
+          const value = cursor.value as { bytes: ArrayBuffer };
+          chunks.push({ seq, path: `idb://${sid}/${seq}`, size: value.bytes.byteLength });
+        }
+        cursor = await cursor.continue();
+      }
+      chunks.sort((a, b) => a.seq - b.seq);
+      return { chunks };
+    } catch (e) {
+      console.warn('listLiveChunks failed on web', e);
+      return { chunks: [] };
+    }
+  }
+
+  public async readLiveChunk(options: { sessionId: string; seq: number }): Promise<ReadLiveChunkResult> {
+    const db = await openLiveChunkDb();
+    const value = await (db as any).get(LIVE_STORE, [options.sessionId, options.seq]);
+    if (!value) {
+      throw new Error(`Chunk not found: ${options.sessionId}/${options.seq}`);
+    }
+    const bytes: ArrayBuffer = value.bytes;
+    return { data: base64FromArrayBuffer(bytes), size: bytes.byteLength };
+  }
+
+  public async deleteLiveChunk(options: { sessionId: string; seq: number }): Promise<GenericResponse> {
+    try {
+      const db = await openLiveChunkDb();
+      await (db as any).delete(LIVE_STORE, [options.sessionId, options.seq]);
+      return { value: true };
+    } catch (e) {
+      console.warn('deleteLiveChunk failed on web', e);
+      return { value: false };
+    }
+  }
+
+  public async deleteLiveChunkSession(options: { sessionId: string }): Promise<GenericResponse> {
+    try {
+      const db = await openLiveChunkDb();
+      const tx = (db as any).transaction(LIVE_STORE, 'readwrite');
+      let cursor = await tx.store.openCursor();
+      while (cursor) {
+        const [sid] = cursor.key as [string, number];
+        if (sid === options.sessionId) {
+          await cursor.delete();
+        }
+        cursor = await cursor.continue();
+      }
+      await tx.done;
+      return { value: true };
+    } catch (e) {
+      console.warn('deleteLiveChunkSession failed on web', e);
+      return { value: false };
+    }
+  }
+
+  public async getLiveChunkSessionInfo(options: { sessionId: string }): Promise<LiveChunkSessionInfo> {
+    const list = await this.listLiveChunks(options);
+    const totalBytes = list.chunks.reduce((acc, c) => acc + c.size, 0);
+    const count = list.chunks.length;
+    const firstSeq = count > 0 ? list.chunks[0].seq : -1;
+    const lastSeq = count > 0 ? list.chunks[count - 1].seq : -1;
+    return { totalBytes, count, firstSeq, lastSeq, dir: `idb://${options.sessionId}` };
+  }
+
+  public async assembleLiveChunksToWav(options: {
+    sessionId: string;
+    outputPath: string;
+    sampleRate?: number;
+    channels?: number;
+  }): Promise<{ filePath: string; msDuration: number; size: number }> {
+    const sampleRate = options.sampleRate ?? 16000;
+    const channels = options.channels ?? 1;
+    const list = await this.listLiveChunks({ sessionId: options.sessionId });
+    let totalBytes = 0;
+    const parts: ArrayBuffer[] = [];
+    for (const c of list.chunks) {
+      const { data } = await this.readLiveChunk({ sessionId: options.sessionId, seq: c.seq });
+      const bin = atob(data);
+      const buf = new ArrayBuffer(bin.length);
+      const view = new Uint8Array(buf);
+      for (let i = 0; i < bin.length; i++) view[i] = bin.charCodeAt(i);
+      parts.push(buf);
+      totalBytes += buf.byteLength;
+    }
+    const wav = new ArrayBuffer(44 + totalBytes);
+    const dv = new DataView(wav);
+    const writeStr = (off: number, s: string) => {
+      for (let i = 0; i < s.length; i++) dv.setUint8(off + i, s.charCodeAt(i));
+    };
+    writeStr(0, 'RIFF');
+    dv.setUint32(4, 36 + totalBytes, true);
+    writeStr(8, 'WAVE');
+    writeStr(12, 'fmt ');
+    dv.setUint32(16, 16, true);
+    dv.setUint16(20, 1, true);
+    dv.setUint16(22, channels, true);
+    dv.setUint32(24, sampleRate, true);
+    dv.setUint32(28, sampleRate * channels * 2, true);
+    dv.setUint16(32, channels * 2, true);
+    dv.setUint16(34, 16, true);
+    writeStr(36, 'data');
+    dv.setUint32(40, totalBytes, true);
+    let off = 44;
+    const out = new Uint8Array(wav);
+    for (const p of parts) {
+      out.set(new Uint8Array(p), off);
+      off += p.byteLength;
+    }
+    const msDuration = Math.round((totalBytes / (sampleRate * channels * 2)) * 1000);
+    return { filePath: options.outputPath, msDuration, size: wav.byteLength };
+  }
+
+  private async persistWebChunk(sessionId: string, seq: number, samples: Float32Array): Promise<string> {
+    const pcm = new ArrayBuffer(samples.length * 2);
+    const view = new DataView(pcm);
+    for (let i = 0; i < samples.length; i++) {
+      let s = Math.max(-1, Math.min(1, samples[i]));
+      view.setInt16(i * 2, s < 0 ? s * 0x8000 : s * 0x7fff, true);
+    }
+    const db = await openLiveChunkDb();
+    await (db as any).put(LIVE_STORE, { sessionId, seq, bytes: pcm });
+    return `idb://${sessionId}/${seq}`;
+  }
+
   private async cleanupStreaming(): Promise<void> {
     this.isStreaming = false;
+    this.persistSessionId = undefined;
+    this.streamingSeq = 0;
 
     if (this.audioWorkletNode) {
       this.audioWorkletNode.disconnect();
@@ -262,7 +428,7 @@ export class VoiceRecorderWeb extends WebPlugin implements VoiceRecorderPlugin {
     }
 
     if (this.mediaStream) {
-      this.mediaStream.getTracks().forEach(track => track.stop());
+      this.mediaStream.getTracks().forEach((track) => track.stop());
       this.mediaStream = undefined;
     }
 

--- a/src/web.ts
+++ b/src/web.ts
@@ -16,6 +16,8 @@ import type {
   ListLiveChunksResult,
   ReadLiveChunkResult,
   LiveChunkSessionInfo,
+  ActiveRecordingSessionResult,
+  RecoverableRecordingSessionsResult,
 } from './definitions';
 
 // IndexedDB-backed live-chunk storage for web parity. Keyed by (sessionId, seq).
@@ -115,6 +117,14 @@ export class VoiceRecorderWeb extends WebPlugin implements VoiceRecorderPlugin {
 
   public getCurrentStatus(): Promise<CurrentRecordingStatus> {
     return Promise.resolve(this.currentStatus);
+  }
+
+  public async getActiveRecordingSession(): Promise<ActiveRecordingSessionResult> {
+    return { value: null };
+  }
+
+  public async listRecoverableRecordingSessions(): Promise<RecoverableRecordingSessionsResult> {
+    return { sessions: [] };
   }
 
   public async getRecordingInfo(options: { filePath: string }): Promise<RecordingInfoData> {


### PR DESCRIPTION
## Summary
- Add native-owned live audio chunk persistence for `startAudioStream` using a caller-provided `persistSessionId`.
- Expose APIs to list sessions/chunks, read and delete persisted chunks, inspect session totals, and assemble a session into a WAV file without loading the full recording into JS memory.
- Add Android foreground-service support for streaming capture, including typed microphone foreground startup and notification stop handling.
- Add Android audio-focus handling and stronger native recording/session metadata for recovery paths.
- Add iOS chunk persistence and WAV assembly support, plus plugin method registration for the new APIs.
- Add a web IndexedDB-backed implementation for the same chunk persistence surface.

## Why
Sales Ask live sessions need audio durability even when the network drops, the WebView is killed, or the app is backgrounded. This moves the source of truth for captured live audio into native/plugin-owned storage before JS handles each chunk, which gives the app a recoverable fallback path instead of losing audio.

## API additions
- `AudioStreamOptions.useForegroundService`
- `AudioStreamOptions.persistSessionId`
- `AudioDataEvent.seq`, `AudioDataEvent.path`, and `AudioDataEvent.downsampled16kMono`
- `listLiveChunkSessions()`
- `listLiveChunks({ sessionId })`
- `readLiveChunk({ sessionId, seq })`
- `deleteLiveChunk({ sessionId, seq })`
- `deleteLiveChunkSession({ sessionId })`
- `getLiveChunkSessionInfo({ sessionId })`
- `assembleLiveChunksToWav({ sessionId, outputPath, sampleRate?, channels? })`

## Consumer
- Required by https://github.com/Sales-Ask/sales-ask-ui/pull/744

## Testing
- `npm run build`

Recommended device QA before merge:
- Android: start streaming with `useForegroundService` and `persistSessionId`, lock/background the app, stop from the notification, and verify chunk cleanup/assembly.
- iOS: stream with `persistSessionId`, interrupt/background the app, and verify persisted chunks can be listed and assembled.
- Web: stream with `persistSessionId` and verify the IndexedDB-backed list/read/delete/assemble path.